### PR TITLE
Signal Echo minigame + MiniGame base class

### DIFF
--- a/include/game/minigame.hpp
+++ b/include/game/minigame.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <cstdint>
+#include "state/state-machine.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * MiniGame is the base class for all minigames in the FDN system.
+ * Each minigame (Signal Echo, Ghost Runner, etc.) derives from MiniGame.
+ *
+ * MiniGame extends StateMachine with:
+ * - Game identity (GameType, display name)
+ * - Outcome tracking (MiniGameOutcome)
+ * - Configure/reset pattern for replayability without reconstruction
+ *
+ * Terminal states call Device::returnToPreviousApp() in managed mode,
+ * or loop back for standalone replay.
+ */
+
+enum class MiniGameResult : uint8_t {
+    IN_PROGRESS = 0,
+    WON = 1,
+    LOST = 2,
+};
+
+struct MiniGameOutcome {
+    MiniGameResult result = MiniGameResult::IN_PROGRESS;
+    int score = 0;
+    bool hardMode = false;
+    bool isComplete() const { return result != MiniGameResult::IN_PROGRESS; }
+};
+
+class MiniGame : public StateMachine {
+public:
+    MiniGame(int stateId, GameType gameType, const char* displayName) :
+      StateMachine(stateId),
+      gameType(gameType),
+      displayName(displayName)
+    {
+    }
+
+    virtual ~MiniGame() = default;
+
+    GameType getGameType() const { return gameType; }
+    const char* getDisplayName() const { return displayName; }
+
+    const MiniGameOutcome& getOutcome() const { return outcome; }
+    bool isGameComplete() const { return outcome.isComplete(); }
+
+    void setOutcome(const MiniGameOutcome& newOutcome) {
+        outcome = newOutcome;
+    }
+
+    virtual void resetGame() {
+        outcome = MiniGameOutcome{};
+    }
+
+protected:
+    MiniGameOutcome outcome;
+
+private:
+    GameType gameType;
+    const char* displayName;
+};

--- a/include/game/signal-echo/signal-echo-resources.hpp
+++ b/include/game/signal-echo/signal-echo-resources.hpp
@@ -1,0 +1,138 @@
+#pragma once
+
+#include "device/drivers/light-interface.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+
+/*
+ * Signal Echo LED palettes.
+ *
+ * signalEchoColors/signalEchoIdleColors: Used by BOTH the NPC device
+ * (walking advertisement) and by players who beat hard mode and equip
+ * the profile. What you see on the NPC is what you get when you win.
+ */
+
+// Primary palette (4 colors) — used for non-idle animations
+const LEDColor signalEchoColors[4] = {
+    LEDColor(255, 0, 255),   // Magenta
+    LEDColor(200, 0, 200),   // Dark magenta
+    LEDColor(255, 50, 200),  // Pink
+    LEDColor(180, 0, 255),   // Purple
+};
+
+// Idle palette (8 colors) — used for idle breathing animation
+const LEDColor signalEchoIdleColors[8] = {
+    LEDColor(255, 0, 255),   LEDColor(200, 0, 200),
+    LEDColor(255, 50, 200),  LEDColor(180, 0, 255),
+    LEDColor(255, 0, 255),   LEDColor(200, 0, 200),
+    LEDColor(255, 50, 200),  LEDColor(180, 0, 255),
+};
+
+// Default/neutral palette — used when no color profile equipped
+const LEDColor defaultProfileColors[4] = {
+    LEDColor(255, 255, 100),  // Warm yellow
+    LEDColor(255, 255, 200),  // Pale yellow
+    LEDColor(255, 255, 255),  // White
+    LEDColor(200, 200, 150),  // Dim warm
+};
+
+const LEDColor defaultProfileIdleColors[8] = {
+    LEDColor(255, 255, 100),  LEDColor(255, 255, 255),
+    LEDColor(255, 255, 200),  LEDColor(200, 200, 150),
+    LEDColor(255, 255, 100),  LEDColor(255, 255, 255),
+    LEDColor(255, 255, 200),  LEDColor(200, 200, 150),
+};
+
+// Signal Echo intro idle LED state — magenta/pink pulse
+const LEDState SIGNAL_ECHO_IDLE_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(
+            signalEchoIdleColors[i % 8], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(
+            signalEchoIdleColors[i % 8], 65);
+    }
+    return state;
+}();
+
+// Win state — rainbow sweep using bright colors
+const LEDColor winRainbowColors[9] = {
+    LEDColor(255, 0, 0),     // Red
+    LEDColor(255, 127, 0),   // Orange
+    LEDColor(255, 255, 0),   // Yellow
+    LEDColor(0, 255, 0),     // Green
+    LEDColor(0, 255, 255),   // Cyan
+    LEDColor(0, 127, 255),   // Sky blue
+    LEDColor(0, 0, 255),     // Blue
+    LEDColor(127, 0, 255),   // Violet
+    LEDColor(255, 0, 255),   // Magenta
+};
+
+const LEDState SIGNAL_ECHO_WIN_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(winRainbowColors[i], 255);
+        state.rightLights[i] = LEDState::SingleLEDState(winRainbowColors[8 - i], 255);
+    }
+    return state;
+}();
+
+// Lose state — red fade
+const LEDState SIGNAL_ECHO_LOSE_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        uint8_t brightness = static_cast<uint8_t>(255 - (i * 25));
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
+    }
+    return state;
+}();
+
+// Error flash — brief red flash on wrong input
+const LEDState SIGNAL_ECHO_ERROR_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+    }
+    return state;
+}();
+
+// Correct input flash — brief green flash
+const LEDState SIGNAL_ECHO_CORRECT_STATE = [](){
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
+        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
+    }
+    return state;
+}();
+
+// Difficulty presets
+inline SignalEchoConfig makeEasyConfig() {
+    SignalEchoConfig c;
+    c.sequenceLength = 4;
+    c.numSequences = 4;
+    c.displaySpeedMs = 600;
+    c.timeLimitMs = 0;
+    c.cumulative = false;
+    c.allowedMistakes = 3;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline SignalEchoConfig makeHardConfig() {
+    SignalEchoConfig c;
+    c.sequenceLength = 8;
+    c.numSequences = 4;
+    c.displaySpeedMs = 400;
+    c.timeLimitMs = 0;
+    c.cumulative = false;
+    c.allowedMistakes = 1;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const SignalEchoConfig SIGNAL_ECHO_EASY = makeEasyConfig();
+const SignalEchoConfig SIGNAL_ECHO_HARD = makeHardConfig();

--- a/include/game/signal-echo/signal-echo-states.hpp
+++ b/include/game/signal-echo/signal-echo-states.hpp
@@ -1,0 +1,177 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class SignalEcho;
+
+/*
+ * Signal Echo state IDs — used for state tracking and test assertions.
+ */
+enum SignalEchoStateId {
+    ECHO_INTRO = 100,
+    ECHO_SHOW_SEQUENCE = 101,
+    ECHO_PLAYER_INPUT = 102,
+    ECHO_EVALUATE = 103,
+    ECHO_WIN = 104,
+    ECHO_LOSE = 105,
+};
+
+/*
+ * EchoIntro — Title screen. Shows "SIGNAL ECHO" and "Watch. Repeat."
+ * Transitions to EchoShowSequence after INTRO_DURATION_MS.
+ * Also seeds the RNG and generates the first sequence.
+ */
+class EchoIntro : public State {
+public:
+    explicit EchoIntro(SignalEcho* game);
+    ~EchoIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToShowSequence();
+
+private:
+    SignalEcho* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToShowSequenceState = false;
+};
+
+/*
+ * EchoShowSequence — Displays the sequence one signal at a time.
+ * Each signal (UP or DOWN) is shown for displaySpeedMs.
+ * After the last signal, transitions to EchoPlayerInput.
+ *
+ * Display: Large arrow (^ or v) + "Signal N of M"
+ * LEDs: Chase up for UP, chase down for DOWN
+ * Haptics: Light pulse per signal
+ */
+class EchoShowSequence : public State {
+public:
+    explicit EchoShowSequence(SignalEcho* game);
+    ~EchoShowSequence() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToPlayerInput();
+
+private:
+    SignalEcho* game;
+    SimpleTimer signalTimer;
+    int currentSignalIndex = 0;
+    bool transitionToPlayerInputState = false;
+    bool displayedCurrentSignal = false;
+
+    void displaySignal(Device* PDN, bool isUp, int index, int total);
+};
+
+/*
+ * EchoPlayerInput — Player reproduces the sequence using buttons.
+ * Primary button = UP, Secondary button = DOWN.
+ *
+ * Correct input: advances inputIndex, adds score.
+ * Wrong input: increments mistakes, advances inputIndex (locked in).
+ *
+ * Transitions to EchoEvaluate when all inputs entered OR when
+ * mistakes exceed allowedMistakes.
+ *
+ * Display: "YOUR TURN" + input progress + round counter + life indicator
+ */
+class EchoPlayerInput : public State {
+public:
+    explicit EchoPlayerInput(SignalEcho* game);
+    ~EchoPlayerInput() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToEvaluate();
+
+private:
+    SignalEcho* game;
+    bool transitionToEvaluateState = false;
+    bool displayIsDirty = false;
+
+    void handleInput(bool isUp, Device* PDN);
+    void renderInputScreen(Device* PDN);
+};
+
+/*
+ * EchoEvaluate — Brief transition state. Checks round outcome:
+ * - If mistakes > allowedMistakes: transition to EchoLose
+ * - If all rounds completed: transition to EchoWin
+ * - Otherwise: advance to next round, transition to EchoShowSequence
+ */
+class EchoEvaluate : public State {
+public:
+    explicit EchoEvaluate(SignalEcho* game);
+    ~EchoEvaluate() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToShowSequence();
+    bool transitionToWin();
+    bool transitionToLose();
+
+private:
+    SignalEcho* game;
+    bool transitionToShowSequenceState = false;
+    bool transitionToWinState = false;
+    bool transitionToLoseState = false;
+};
+
+/*
+ * EchoWin — Victory screen. Shows "ACCESS GRANTED" + score.
+ * Sets outcome to WON. In standalone mode, transitions back to EchoIntro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ *
+ * LEDs: Rainbow sweep
+ * Haptics: Celebration pattern
+ */
+class EchoWin : public State {
+public:
+    explicit EchoWin(SignalEcho* game);
+    ~EchoWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SignalEcho* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * EchoLose — Defeat screen. Shows "SIGNAL LOST".
+ * Sets outcome to LOST. In standalone mode, transitions back to EchoIntro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ *
+ * LEDs: Red fade
+ * Haptics: Long buzz
+ */
+class EchoLose : public State {
+public:
+    explicit EchoLose(SignalEcho* game);
+    ~EchoLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SignalEcho* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/signal-echo/signal-echo.hpp
+++ b/include/game/signal-echo/signal-echo.hpp
@@ -1,0 +1,86 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "utils/simple-timer.hpp"
+#include <vector>
+#include <cstdlib>
+
+/*
+ * Signal Echo configuration — all tuning variables for difficulty.
+ * Two presets are defined in signal-echo-resources.hpp:
+ * SIGNAL_ECHO_EASY (default) and SIGNAL_ECHO_HARD.
+ */
+struct SignalEchoConfig {
+    int sequenceLength = 4;
+    int numSequences = 3;
+    int displaySpeedMs = 600;
+    int timeLimitMs = 0;
+    bool cumulative = false;
+    int allowedMistakes = 2;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+/*
+ * Signal Echo session state — tracks the current game in progress.
+ * Reset between games (on lose/restart). Win/lose is tracked via
+ * MiniGame::outcome, not duplicated here.
+ */
+struct SignalEchoSession {
+    std::vector<bool> currentSequence;
+    int currentRound = 0;
+    int inputIndex = 0;
+    int mistakes = 0;
+    int score = 0;
+
+    void reset() {
+        currentSequence.clear();
+        currentRound = 0;
+        inputIndex = 0;
+        mistakes = 0;
+        score = 0;
+    }
+};
+
+constexpr int SIGNAL_ECHO_APP_ID = 2;
+
+/*
+ * Signal Echo (Simon Says) — the first MiniGame implementation.
+ *
+ * The device plays a sequence of UP/DOWN signals, then the player
+ * reproduces it from memory. Correct replay advances to the next round.
+ * Wrong input counts as a mistake. Too many mistakes = lose.
+ * Complete all rounds = win.
+ *
+ * In standalone mode, sequences are generated locally using a seeded
+ * PRNG. In managed mode, sequences come from the NPC via serial.
+ * Terminal states call Device::returnToPreviousApp() in managed mode,
+ * or loop back to EchoIntro for standalone replay.
+ */
+class SignalEcho : public MiniGame {
+public:
+    explicit SignalEcho(SignalEchoConfig config);
+    void populateStateMap() override;
+    void resetGame() override;
+
+    SignalEchoConfig& getConfig() { return config; }
+    SignalEchoSession& getSession() { return session; }
+
+    /*
+     * Generate a sequence of the given length using the seeded PRNG.
+     * true = UP, false = DOWN.
+     */
+    std::vector<bool> generateSequence(int length);
+
+    /*
+     * Seed the PRNG. Called once during initialization.
+     * If config.rngSeed != 0, uses that seed (deterministic for tests).
+     * Otherwise uses 0 (production would use MAC address, but standalone
+     * mode falls back to time-based or 0).
+     */
+    void seedRng();
+
+private:
+    SignalEchoConfig config;
+    SignalEchoSession session;
+};

--- a/src/game/signal-echo/echo-evaluate.cpp
+++ b/src/game/signal-echo/echo-evaluate.cpp
@@ -1,0 +1,71 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoEvaluate::EchoEvaluate(SignalEcho* game) : State(ECHO_EVALUATE) {
+    this->game = game;
+}
+
+EchoEvaluate::~EchoEvaluate() {
+    game = nullptr;
+}
+
+void EchoEvaluate::onStateMounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+    transitionToWinState = false;
+    transitionToLoseState = false;
+
+    auto& session = game->getSession();
+    auto& config = game->getConfig();
+
+    // Check if player has exceeded allowed mistakes
+    if (session.mistakes > config.allowedMistakes) {
+        transitionToLoseState = true;
+        return;
+    }
+
+    // Round completed successfully — advance
+    session.currentRound++;
+
+    // Check if all rounds completed
+    if (session.currentRound >= config.numSequences) {
+        transitionToWinState = true;
+        return;
+    }
+
+    // Generate next sequence
+    if (config.cumulative) {
+        // Cumulative mode: append one more element
+        session.currentSequence.push_back(rand() % 2 == 0);
+    } else {
+        // Fresh mode: completely new sequence
+        session.currentSequence = game->generateSequence(config.sequenceLength);
+    }
+
+    // Reset input index for the new round
+    session.inputIndex = 0;
+
+    transitionToShowSequenceState = true;
+}
+
+void EchoEvaluate::onStateLoop(Device* PDN) {
+    // Transitions are determined in onStateMounted — nothing to do here
+}
+
+void EchoEvaluate::onStateDismounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+    transitionToWinState = false;
+    transitionToLoseState = false;
+}
+
+bool EchoEvaluate::transitionToShowSequence() {
+    return transitionToShowSequenceState;
+}
+
+bool EchoEvaluate::transitionToWin() {
+    return transitionToWinState;
+}
+
+bool EchoEvaluate::transitionToLose() {
+    return transitionToLoseState;
+}

--- a/src/game/signal-echo/echo-intro.cpp
+++ b/src/game/signal-echo/echo-intro.cpp
@@ -1,0 +1,59 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoIntro::EchoIntro(SignalEcho* game) : State(ECHO_INTRO) {
+    this->game = game;
+}
+
+EchoIntro::~EchoIntro() {
+    game = nullptr;
+}
+
+void EchoIntro::onStateMounted(Device* PDN) {
+    transitionToShowSequenceState = false;
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Seed RNG and generate the first sequence
+    game->seedRng();
+    game->getSession().currentSequence = game->generateSequence(
+        game->getConfig().sequenceLength);
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SIGNAL ECHO", 15, 20)
+        ->drawText("Watch. Repeat.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start idle LED animation
+    AnimationConfig config;
+    config.type = AnimationType::IDLE;
+    config.speed = 16;
+    config.curve = EaseCurve::LINEAR;
+    config.initialState = SIGNAL_ECHO_IDLE_STATE;
+    config.loopDelayMs = 0;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Start intro timer
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void EchoIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToShowSequenceState = true;
+    }
+}
+
+void EchoIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToShowSequenceState = false;
+}
+
+bool EchoIntro::transitionToShowSequence() {
+    return transitionToShowSequenceState;
+}

--- a/src/game/signal-echo/echo-lose.cpp
+++ b/src/game/signal-echo/echo-lose.cpp
@@ -1,0 +1,71 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoLose::EchoLose(SignalEcho* game) : State(ECHO_LOSE) {
+    this->game = game;
+}
+
+EchoLose::~EchoLose() {
+    game = nullptr;
+}
+
+void EchoLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    auto& session = game->getSession();
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = session.score;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    // Display defeat screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SIGNAL LOST", 20, 30);
+    PDN->getDisplay()->render();
+
+    // Red fade LED
+    AnimationConfig config;
+    config.type = AnimationType::IDLE;
+    config.speed = 8;
+    config.curve = EaseCurve::LINEAR;
+    config.initialState = SIGNAL_ECHO_LOSE_STATE;
+    config.loopDelayMs = 0;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Long haptic buzz
+    PDN->getHaptics()->max();
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void EchoLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void EchoLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool EchoLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/signal-echo/echo-player-input.cpp
+++ b/src/game/signal-echo/echo-player-input.cpp
@@ -1,0 +1,135 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoPlayerInput::EchoPlayerInput(SignalEcho* game) : State(ECHO_PLAYER_INPUT) {
+    this->game = game;
+}
+
+EchoPlayerInput::~EchoPlayerInput() {
+    game = nullptr;
+}
+
+void EchoPlayerInput::onStateMounted(Device* PDN) {
+    transitionToEvaluateState = false;
+    displayIsDirty = true;
+
+    // Set up button callbacks
+    parameterizedCallbackFunction upCallback = [](void* ctx) {
+        auto* state = static_cast<EchoPlayerInput*>(ctx);
+        state->handleInput(true, nullptr);
+    };
+
+    parameterizedCallbackFunction downCallback = [](void* ctx) {
+        auto* state = static_cast<EchoPlayerInput*>(ctx);
+        state->handleInput(false, nullptr);
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(upCallback, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(downCallback, this, ButtonInteraction::CLICK);
+
+    renderInputScreen(PDN);
+}
+
+void EchoPlayerInput::onStateLoop(Device* PDN) {
+    if (displayIsDirty) {
+        renderInputScreen(PDN);
+        displayIsDirty = false;
+    }
+
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    // Check if all inputs have been entered
+    if (session.inputIndex >= seqLen) {
+        transitionToEvaluateState = true;
+        return;
+    }
+
+    // Check if mistakes exceeded allowed
+    if (session.mistakes > game->getConfig().allowedMistakes) {
+        transitionToEvaluateState = true;
+        return;
+    }
+}
+
+void EchoPlayerInput::onStateDismounted(Device* PDN) {
+    transitionToEvaluateState = false;
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+    PDN->getHaptics()->off();
+}
+
+bool EchoPlayerInput::transitionToEvaluate() {
+    return transitionToEvaluateState;
+}
+
+void EchoPlayerInput::handleInput(bool isUp, Device* PDN) {
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    if (session.inputIndex >= seqLen) {
+        return;  // Already completed input for this round
+    }
+
+    bool expected = session.currentSequence[session.inputIndex];
+
+    if (isUp == expected) {
+        // Correct input
+        session.score += 100;
+    } else {
+        // Wrong input — count mistake, advance anyway (locked in)
+        session.mistakes++;
+    }
+
+    // Always advance to next position
+    session.inputIndex++;
+    displayIsDirty = true;
+}
+
+void EchoPlayerInput::renderInputScreen(Device* PDN) {
+    auto& session = game->getSession();
+    auto& config = game->getConfig();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("YOUR TURN", 25, 12);
+
+    // Build input progress string
+    std::string inputProgress;
+    for (int i = 0; i < seqLen; i++) {
+        if (i < session.inputIndex) {
+            bool expected = session.currentSequence[i];
+            if (expected) {
+                inputProgress += "^ ";
+            } else {
+                inputProgress += "v ";
+            }
+        } else {
+            inputProgress += "_ ";
+        }
+    }
+
+    PDN->getDisplay()->drawText(inputProgress.c_str(), 5, 35);
+
+    // Round counter + life indicator
+    int livesRemaining = config.allowedMistakes - session.mistakes;
+    if (livesRemaining < 0) livesRemaining = 0;
+
+    std::string roundInfo = "Round " + std::to_string(session.currentRound + 1) +
+                            "/" + std::to_string(config.numSequences);
+
+    std::string lives;
+    for (int i = 0; i < config.allowedMistakes; i++) {
+        if (i < livesRemaining) {
+            lives += "* ";  // Remaining life (filled)
+        } else {
+            lives += "o ";  // Lost life (empty)
+        }
+    }
+
+    PDN->getDisplay()->drawText(roundInfo.c_str(), 5, 55);
+    PDN->getDisplay()->drawText(lives.c_str(), 80, 55);
+    PDN->getDisplay()->render();
+}

--- a/src/game/signal-echo/echo-show-sequence.cpp
+++ b/src/game/signal-echo/echo-show-sequence.cpp
@@ -1,0 +1,96 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoShowSequence::EchoShowSequence(SignalEcho* game) : State(ECHO_SHOW_SEQUENCE) {
+    this->game = game;
+}
+
+EchoShowSequence::~EchoShowSequence() {
+    game = nullptr;
+}
+
+void EchoShowSequence::onStateMounted(Device* PDN) {
+    transitionToPlayerInputState = false;
+    currentSignalIndex = 0;
+    displayedCurrentSignal = false;
+
+    // Reset input index for the new round
+    game->getSession().inputIndex = 0;
+}
+
+void EchoShowSequence::onStateLoop(Device* PDN) {
+    auto& session = game->getSession();
+    int seqLen = static_cast<int>(session.currentSequence.size());
+
+    if (currentSignalIndex >= seqLen) {
+        // All signals shown — transition to player input
+        transitionToPlayerInputState = true;
+        return;
+    }
+
+    if (!displayedCurrentSignal) {
+        // Display the current signal
+        bool isUp = session.currentSequence[currentSignalIndex];
+        displaySignal(PDN, isUp, currentSignalIndex, seqLen);
+
+        // Light pulse haptic feedback per signal
+        PDN->getHaptics()->setIntensity(128);
+
+        // Start timer for this signal's display duration
+        signalTimer.setTimer(game->getConfig().displaySpeedMs);
+        displayedCurrentSignal = true;
+    }
+
+    if (signalTimer.expired()) {
+        PDN->getHaptics()->off();
+        currentSignalIndex++;
+        displayedCurrentSignal = false;
+    }
+}
+
+void EchoShowSequence::onStateDismounted(Device* PDN) {
+    signalTimer.invalidate();
+    transitionToPlayerInputState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoShowSequence::transitionToPlayerInput() {
+    return transitionToPlayerInputState;
+}
+
+void EchoShowSequence::displaySignal(Device* PDN, bool isUp, int index, int total) {
+    PDN->getDisplay()->invalidateScreen();
+
+    if (isUp) {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+            ->drawText("^", 60, 25)
+            ->drawText("UP", 55, 40);
+    } else {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+            ->drawText("v", 60, 25)
+            ->drawText("DOWN", 48, 40);
+    }
+
+    // Progress indicator: "Signal N of M"
+    std::string progress = "Signal " + std::to_string(index + 1) +
+                           " of " + std::to_string(total);
+    PDN->getDisplay()->drawText(progress.c_str(), 20, 58);
+    PDN->getDisplay()->render();
+
+    // LED chase direction matches signal direction
+    AnimationConfig ledConfig;
+    ledConfig.type = AnimationType::VERTICAL_CHASE;
+    ledConfig.speed = 8;
+    ledConfig.curve = EaseCurve::EASE_OUT;
+    ledConfig.loop = false;
+
+    LEDState state;
+    for (int i = 0; i < 9; i++) {
+        LEDColor color = signalEchoColors[i % 4];
+        state.leftLights[i] = LEDState::SingleLEDState(color, 200);
+        state.rightLights[i] = LEDState::SingleLEDState(color, 200);
+    }
+    ledConfig.initialState = state;
+    PDN->getLightManager()->startAnimation(ledConfig);
+}

--- a/src/game/signal-echo/echo-win.cpp
+++ b/src/game/signal-echo/echo-win.cpp
@@ -1,0 +1,78 @@
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+EchoWin::EchoWin(SignalEcho* game) : State(ECHO_WIN) {
+    this->game = game;
+}
+
+EchoWin::~EchoWin() {
+    game = nullptr;
+}
+
+void EchoWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    auto& session = game->getSession();
+
+    // Determine if this was a hard mode win
+    bool isHard = (game->getConfig().allowedMistakes <= 1 &&
+                   game->getConfig().sequenceLength >= 8);
+
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = session.score;
+    winOutcome.hardMode = isHard;
+    game->setOutcome(winOutcome);
+
+    // Display victory screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("ACCESS GRANTED", 5, 25);
+
+    std::string scoreStr = "Score: " + std::to_string(session.score);
+    PDN->getDisplay()->drawText(scoreStr.c_str(), 30, 50);
+    PDN->getDisplay()->render();
+
+    // Rainbow LED sweep
+    AnimationConfig config;
+    config.type = AnimationType::VERTICAL_CHASE;
+    config.speed = 5;
+    config.curve = EaseCurve::EASE_IN_OUT;
+    config.initialState = SIGNAL_ECHO_WIN_STATE;
+    config.loopDelayMs = 500;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
+
+    // Celebration haptic
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void EchoWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void EchoWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool EchoWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool EchoWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/signal-echo/signal-echo.cpp
+++ b/src/game/signal-echo/signal-echo.cpp
@@ -1,0 +1,89 @@
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+
+SignalEcho::SignalEcho(SignalEchoConfig config) :
+    MiniGame(SIGNAL_ECHO_APP_ID, GameType::SIGNAL_ECHO, "SIGNAL ECHO"),
+    config(config)
+{
+}
+
+void SignalEcho::populateStateMap() {
+    seedRng();
+
+    EchoIntro* intro = new EchoIntro(this);
+    EchoShowSequence* showSequence = new EchoShowSequence(this);
+    EchoPlayerInput* playerInput = new EchoPlayerInput(this);
+    EchoEvaluate* evaluate = new EchoEvaluate(this);
+    EchoWin* win = new EchoWin(this);
+    EchoLose* lose = new EchoLose(this);
+
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&EchoIntro::transitionToShowSequence, intro),
+            showSequence));
+
+    showSequence->addTransition(
+        new StateTransition(
+            std::bind(&EchoShowSequence::transitionToPlayerInput, showSequence),
+            playerInput));
+
+    playerInput->addTransition(
+        new StateTransition(
+            std::bind(&EchoPlayerInput::transitionToEvaluate, playerInput),
+            evaluate));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToShowSequence, evaluate),
+            showSequence));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToWin, evaluate),
+            win));
+
+    evaluate->addTransition(
+        new StateTransition(
+            std::bind(&EchoEvaluate::transitionToLose, evaluate),
+            lose));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&EchoWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&EchoLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(showSequence);
+    stateMap.push_back(playerInput);
+    stateMap.push_back(evaluate);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void SignalEcho::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}
+
+void SignalEcho::seedRng() {
+    if (config.rngSeed != 0) {
+        srand(static_cast<unsigned int>(config.rngSeed));
+    } else {
+        srand(static_cast<unsigned int>(0));
+    }
+}
+
+std::vector<bool> SignalEcho::generateSequence(int length) {
+    std::vector<bool> seq;
+    for (int i = 0; i < length; i++) {
+        seq.push_back(rand() % 2 == 0);
+    }
+    return seq;
+}

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -14,6 +14,7 @@
 #include "fdn-game-tests.hpp"
 #include "cli-fdn-tests.hpp"
 #include "device-extension-tests.hpp"
+#include "signal-echo-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -485,6 +486,114 @@ TEST_F(DeviceExtensionTestSuite, GetAppReturnsNull) {
 
 TEST_F(DeviceExtensionTestSuite, ReturnToPrevious) {
     deviceExtensionReturnToPrevious(this);
+}
+
+// ============================================
+// SIGNAL ECHO TESTS
+// ============================================
+
+TEST_F(SignalEchoTestSuite, SequenceGenerationLength) {
+    echoSequenceGenerationLength(this);
+}
+
+TEST_F(SignalEchoTestSuite, SequenceGenerationMixed) {
+    echoSequenceGenerationMixed(this);
+}
+
+TEST_F(SignalEchoTestSuite, IntroTransitionsToShow) {
+    echoIntroTransitionsToShow(this);
+}
+
+TEST_F(SignalEchoTestSuite, ShowSequenceDisplaysSignals) {
+    echoShowSequenceDisplaysSignals(this);
+}
+
+TEST_F(SignalEchoTestSuite, ShowTransitionsToInput) {
+    echoShowTransitionsToInput(this);
+}
+
+TEST_F(SignalEchoTestSuite, CorrectInputAdvancesIndex) {
+    echoCorrectInputAdvancesIndex(this);
+}
+
+TEST_F(SignalEchoTestSuite, WrongInputCountsMistake) {
+    echoWrongInputCountsMistake(this);
+}
+
+TEST_F(SignalEchoTestSuite, AllCorrectInputsNextRound) {
+    echoAllCorrectInputsNextRound(this);
+}
+
+TEST_F(SignalEchoTestSuite, MistakesExhaustedLose) {
+    echoMistakesExhaustedLose(this);
+}
+
+TEST_F(SignalEchoTestSuite, AllRoundsCompletedWin) {
+    echoAllRoundsCompletedWin(this);
+}
+
+TEST_F(SignalEchoTestSuite, CumulativeModeAppends) {
+    echoCumulativeModeAppends(this);
+}
+
+TEST_F(SignalEchoTestSuite, FreshModeNewSequence) {
+    echoFreshModeNewSequence(this);
+}
+
+TEST_F(SignalEchoTestSuite, WinSetsOutcome) {
+    echoWinSetsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, LoseSetsOutcome) {
+    echoLoseSetsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, IsGameCompleteAfterWin) {
+    echoIsGameCompleteAfterWin(this);
+}
+
+TEST_F(SignalEchoTestSuite, ResetGameClearsOutcome) {
+    echoResetGameClearsOutcome(this);
+}
+
+TEST_F(SignalEchoTestSuite, StandaloneRestartAfterWin) {
+    echoStandaloneRestartAfterWin(this);
+}
+
+// ============================================
+// SIGNAL ECHO DIFFICULTY TESTS
+// ============================================
+
+TEST_F(SignalEchoDifficultyTestSuite, EasySequenceLength) {
+    echoDiffEasySequenceLength(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, Easy3MistakesAllowed) {
+    echoDiffEasy3MistakesAllowed(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HardSequenceLength) {
+    echoDiffHardSequenceLength(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, Hard1MistakeAllowed) {
+    echoDiffHard1MistakeAllowed(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, EasyWinOutcome) {
+    echoDiffEasyWinOutcome(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, HardWinOutcome) {
+    echoDiffHardWinOutcome(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, LifeIndicator) {
+    echoDiffLifeIndicator(this);
+}
+
+TEST_F(SignalEchoDifficultyTestSuite, WrongInputAdvances) {
+    echoDiffWrongInputAdvances(this);
 }
 
 // ============================================

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -1,0 +1,625 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "game/signal-echo/signal-echo.hpp"
+#include "game/signal-echo/signal-echo-states.hpp"
+#include "game/signal-echo/signal-echo-resources.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// SIGNAL ECHO TEST SUITE
+// ============================================
+
+class SignalEchoTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createGameDevice(0, "signal-echo");
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+        game_ = dynamic_cast<SignalEcho*>(device_.game);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    DeviceInstance device_;
+    SignalEcho* game_ = nullptr;
+};
+
+// ============================================
+// SEQUENCE GENERATION TESTS
+// ============================================
+
+// Test: Generated sequence has correct length
+void echoSequenceGenerationLength(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 6;
+    config.rngSeed = 42;
+
+    SignalEcho tempGame(config);
+    tempGame.seedRng();
+    std::vector<bool> seq = tempGame.generateSequence(6);
+    ASSERT_EQ(static_cast<int>(seq.size()), 6);
+
+    std::vector<bool> seq2 = tempGame.generateSequence(10);
+    ASSERT_EQ(static_cast<int>(seq2.size()), 10);
+}
+
+// Test: Sequence contains both UP and DOWN (statistical)
+void echoSequenceGenerationMixed(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.rngSeed = 42;
+
+    SignalEcho tempGame(config);
+    tempGame.seedRng();
+
+    std::vector<bool> seq = tempGame.generateSequence(100);
+    int ups = 0, downs = 0;
+    for (bool val : seq) {
+        if (val) ups++;
+        else downs++;
+    }
+    ASSERT_GT(ups, 0) << "Expected at least one UP in 100 elements";
+    ASSERT_GT(downs, 0) << "Expected at least one DOWN in 100 elements";
+}
+
+// ============================================
+// STATE TRANSITION TESTS
+// ============================================
+
+// Test: EchoIntro transitions to EchoShowSequence after timer
+void echoIntroTransitionsToShow(SignalEchoTestSuite* suite) {
+    State* state = suite->game_->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), ECHO_INTRO);
+
+    // Advance past 2s intro timer
+    suite->tickWithTime(30, 100);
+
+    state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+}
+
+// Test: ShowSequence displays signals
+void echoShowSequenceDisplaysSignals(SignalEchoTestSuite* suite) {
+    suite->game_->skipToState(suite->device_.pdn, 1);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+
+    // Run a few loops — should still be showing
+    suite->tick(2);
+    state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_SHOW_SEQUENCE);
+}
+
+// Test: ShowSequence transitions to PlayerInput after all signals
+void echoShowTransitionsToInput(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 50;
+    suite->game_->getSession().currentSequence = {true, false};
+
+    suite->game_->skipToState(suite->device_.pdn, 1);
+
+    // Advance enough time for both signals to display
+    suite->tickWithTime(20, 60);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_PLAYER_INPUT);
+}
+
+// ============================================
+// PLAYER INPUT TESTS
+// ============================================
+
+// Test: Correct button press advances inputIndex
+void echoCorrectInputAdvancesIndex(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getSession().currentSequence = {true, false, true, false};
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(suite->device_.pdn, 2);
+    suite->tick(1);
+
+    // Sequence: UP, DOWN, UP, DOWN. Press UP — correct for position 0
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    ASSERT_EQ(suite->game_->getSession().inputIndex, 1);
+    ASSERT_EQ(suite->game_->getSession().mistakes, 0);
+}
+
+// Test: Wrong button press increments mistakes
+void echoWrongInputCountsMistake(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getSession().currentSequence = {true, false, true, false};
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(suite->device_.pdn, 2);
+    suite->tick(1);
+
+    // Sequence starts with UP, press DOWN — wrong
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    ASSERT_EQ(suite->game_->getSession().inputIndex, 1);  // Still advances
+    ASSERT_EQ(suite->game_->getSession().mistakes, 1);
+}
+
+// Test: Completing all inputs correctly leads to next round via Evaluate
+void echoAllCorrectInputsNextRound(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().numSequences = 3;
+    suite->game_->getConfig().sequenceLength = 2;
+    suite->game_->getConfig().allowedMistakes = 3;
+    suite->game_->getSession().currentSequence = {true, false};
+    suite->game_->getSession().currentRound = 0;
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(suite->device_.pdn, 2);
+    suite->tick(1);
+
+    // Press correct buttons: UP then DOWN
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(4);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_TRUE(state->getStateId() == ECHO_EVALUATE ||
+                state->getStateId() == ECHO_SHOW_SEQUENCE);
+}
+
+// Test: Exceeding allowed mistakes leads to EchoLose
+void echoMistakesExhaustedLose(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().allowedMistakes = 1;
+    suite->game_->getConfig().sequenceLength = 4;
+    suite->game_->getSession().currentSequence = {true, true, true, true};
+    suite->game_->getSession().inputIndex = 0;
+    suite->game_->getSession().mistakes = 0;
+
+    suite->game_->skipToState(suite->device_.pdn, 2);
+    suite->tick(1);
+
+    // Press wrong button twice (allowedMistakes = 1, 2nd exceeds)
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(5);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+}
+
+// Test: All rounds completed successfully leads to EchoWin
+void echoAllRoundsCompletedWin(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().displaySpeedMs = 10;
+    suite->game_->getConfig().numSequences = 1;
+    suite->game_->getConfig().sequenceLength = 2;
+    suite->game_->getConfig().allowedMistakes = 3;
+    suite->game_->getSession().currentSequence = {true, false};
+    suite->game_->getSession().currentRound = 0;
+    suite->game_->getSession().inputIndex = 0;
+
+    suite->game_->skipToState(suite->device_.pdn, 2);
+    suite->tick(1);
+
+    // Enter correct sequence
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(5);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_WIN);
+}
+
+// ============================================
+// CUMULATIVE & FRESH MODE TESTS
+// ============================================
+
+// Test: Cumulative mode appends one element each round
+void echoCumulativeModeAppends(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 3;
+    config.numSequences = 3;
+    config.cumulative = true;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.allowedMistakes = 10;
+
+    SignalEcho* customGame = new SignalEcho(config);
+    customGame->initialize(suite->device_.pdn);
+
+    // First round sequence should be length 3
+    int firstLen = static_cast<int>(customGame->getSession().currentSequence.size());
+    ASSERT_EQ(firstLen, 3);
+
+    // Simulate completing a round
+    auto& session = customGame->getSession();
+    session.inputIndex = firstLen;
+    session.currentRound = 0;
+
+    // Trigger evaluate logic
+    customGame->skipToState(suite->device_.pdn, 3);
+    ASSERT_EQ(session.currentRound, 1);
+    ASSERT_EQ(static_cast<int>(session.currentSequence.size()), 4);
+
+    delete customGame;
+}
+
+// Test: Fresh mode generates new sequence each round
+void echoFreshModeNewSequence(SignalEchoTestSuite* suite) {
+    SignalEchoConfig config;
+    config.sequenceLength = 4;
+    config.numSequences = 3;
+    config.cumulative = false;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.allowedMistakes = 10;
+
+    SignalEcho* customGame = new SignalEcho(config);
+    customGame->initialize(suite->device_.pdn);
+
+    auto& session = customGame->getSession();
+
+    // Simulate completing round 0
+    session.inputIndex = 4;
+    session.currentRound = 0;
+
+    customGame->skipToState(suite->device_.pdn, 3);
+    ASSERT_EQ(session.currentRound, 1);
+    ASSERT_EQ(static_cast<int>(session.currentSequence.size()), 4);
+
+    delete customGame;
+}
+
+// ============================================
+// OUTCOME & GAME COMPLETE TESTS
+// ============================================
+
+// Test: EchoWin sets outcome to WON with score
+void echoWinSetsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->getSession().score = 400;
+    suite->game_->skipToState(suite->device_.pdn, 4);
+
+    const MiniGameOutcome& outcome = suite->game_->getOutcome();
+    ASSERT_EQ(outcome.result, MiniGameResult::WON);
+    ASSERT_EQ(outcome.score, 400);
+}
+
+// Test: EchoLose sets outcome to LOST
+void echoLoseSetsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->getSession().score = 200;
+    suite->game_->skipToState(suite->device_.pdn, 5);
+
+    const MiniGameOutcome& outcome = suite->game_->getOutcome();
+    ASSERT_EQ(outcome.result, MiniGameResult::LOST);
+    ASSERT_EQ(outcome.score, 200);
+}
+
+// Test: isGameComplete returns true after win
+void echoIsGameCompleteAfterWin(SignalEchoTestSuite* suite) {
+    ASSERT_FALSE(suite->game_->isGameComplete());
+
+    suite->game_->skipToState(suite->device_.pdn, 4);
+    ASSERT_TRUE(suite->game_->isGameComplete());
+}
+
+// Test: resetGame clears outcome back to IN_PROGRESS
+void echoResetGameClearsOutcome(SignalEchoTestSuite* suite) {
+    suite->game_->skipToState(suite->device_.pdn, 4);
+    ASSERT_TRUE(suite->game_->isGameComplete());
+
+    suite->game_->resetGame();
+    ASSERT_FALSE(suite->game_->isGameComplete());
+    ASSERT_EQ(suite->game_->getOutcome().result, MiniGameResult::IN_PROGRESS);
+}
+
+// Test: In standalone mode, EchoWin loops back to EchoIntro
+void echoStandaloneRestartAfterWin(SignalEchoTestSuite* suite) {
+    suite->game_->getConfig().managedMode = false;
+    suite->game_->skipToState(suite->device_.pdn, 4);
+
+    // Advance past 3s win display timer
+    suite->tickWithTime(40, 100);
+
+    State* state = suite->game_->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_INTRO);
+}
+
+// ============================================
+// DIFFICULTY TEST SUITE
+// ============================================
+
+class SignalEchoDifficultyTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        // Shared clock for deterministic timing
+        globalClock_ = new NativeClockDriver("test_diff_clock");
+        SimpleTimer::setPlatformClock(globalClock_);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        delete globalClock_;
+    }
+
+    DeviceInstance createDeviceWithConfig(SignalEchoConfig config) {
+        DeviceInstance instance;
+        instance.deviceIndex = 0;
+        instance.isHunter = false;
+
+        char idBuffer[5];
+        snprintf(idBuffer, sizeof(idBuffer), "%04d", 10);
+        instance.deviceId = idBuffer;
+
+        std::string suffix = "_diff_0";
+
+        instance.loggerDriver = new NativeLoggerDriver(LOGGER_DRIVER_NAME + suffix);
+        instance.loggerDriver->setSuppressOutput(true);
+        instance.clockDriver = new NativeClockDriver(PLATFORM_CLOCK_DRIVER_NAME + suffix);
+        instance.displayDriver = new NativeDisplayDriver(DISPLAY_DRIVER_NAME + suffix);
+        instance.primaryButtonDriver = new NativeButtonDriver(PRIMARY_BUTTON_DRIVER_NAME + suffix, 0);
+        instance.secondaryButtonDriver = new NativeButtonDriver(SECONDARY_BUTTON_DRIVER_NAME + suffix, 1);
+        instance.lightDriver = new NativeLightStripDriver(LIGHT_DRIVER_NAME + suffix);
+        instance.hapticsDriver = new NativeHapticsDriver(HAPTICS_DRIVER_NAME + suffix, 0);
+        instance.serialOutDriver = new NativeSerialDriver(SERIAL_OUT_DRIVER_NAME + suffix);
+        instance.serialInDriver = new NativeSerialDriver(SERIAL_IN_DRIVER_NAME + suffix);
+        instance.httpClientDriver = new NativeHttpClientDriver(HTTP_CLIENT_DRIVER_NAME + suffix);
+        instance.httpClientDriver->setMockServerEnabled(true);
+        instance.httpClientDriver->setConnected(true);
+        instance.peerCommsDriver = new NativePeerCommsDriver(PEER_COMMS_DRIVER_NAME + suffix);
+        instance.storageDriver = new NativePrefsDriver(STORAGE_DRIVER_NAME + suffix);
+
+        DriverConfig pdnConfig = {
+            {DISPLAY_DRIVER_NAME, instance.displayDriver},
+            {PRIMARY_BUTTON_DRIVER_NAME, instance.primaryButtonDriver},
+            {SECONDARY_BUTTON_DRIVER_NAME, instance.secondaryButtonDriver},
+            {LIGHT_DRIVER_NAME, instance.lightDriver},
+            {HAPTICS_DRIVER_NAME, instance.hapticsDriver},
+            {SERIAL_OUT_DRIVER_NAME, instance.serialOutDriver},
+            {SERIAL_IN_DRIVER_NAME, instance.serialInDriver},
+            {HTTP_CLIENT_DRIVER_NAME, instance.httpClientDriver},
+            {PEER_COMMS_DRIVER_NAME, instance.peerCommsDriver},
+            {PLATFORM_CLOCK_DRIVER_NAME, instance.clockDriver},
+            {LOGGER_DRIVER_NAME, instance.loggerDriver},
+            {STORAGE_DRIVER_NAME, instance.storageDriver},
+        };
+
+        instance.pdn = PDN::createPDN(pdnConfig);
+        instance.pdn->begin();
+
+        instance.player = nullptr;
+        instance.quickdrawWirelessManager = nullptr;
+
+        instance.game = new SignalEcho(config);
+
+        AppConfig apps = {
+            {StateId(SIGNAL_ECHO_APP_ID), instance.game}
+        };
+        instance.pdn->loadAppConfig(apps, StateId(SIGNAL_ECHO_APP_ID));
+
+        return instance;
+    }
+
+    void destroyDevice(DeviceInstance& device) {
+        delete device.game;
+        delete device.pdn;
+    }
+
+    NativeClockDriver* globalClock_ = nullptr;
+};
+
+// Test: Easy config generates 4-element sequences
+void echoDiffEasySequenceLength(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    ASSERT_EQ(static_cast<int>(game->getSession().currentSequence.size()),
+              config.sequenceLength);
+    ASSERT_EQ(config.sequenceLength, 4);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Easy mode allows 3 mistakes before losing
+void echoDiffEasy3MistakesAllowed(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(device.pdn, 2);
+    device.pdn->loop();
+
+    // Press wrong 3 times — should still be in game
+    for (int i = 0; i < 3; i++) {
+        device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(game->getSession().mistakes, 3);
+
+    State* state = game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_PLAYER_INPUT);
+
+    // 4th wrong press exceeds the limit
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+    }
+
+    state = game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard config generates 8-element sequences
+void echoDiffHardSequenceLength(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    ASSERT_EQ(static_cast<int>(game->getSession().currentSequence.size()),
+              config.sequenceLength);
+    ASSERT_EQ(config.sequenceLength, 8);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard mode — 2nd wrong press causes lose
+void echoDiffHard1MistakeAllowed(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, true, true, true, true, true, true, true};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(device.pdn, 2);
+    device.pdn->loop();
+
+    // First wrong press
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    ASSERT_EQ(game->getSession().mistakes, 1);
+
+    // Second wrong press exceeds allowedMistakes (1)
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+    }
+
+    State* state = game->getCurrentState();
+    ASSERT_EQ(state->getStateId(), ECHO_LOSE);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Easy mode win sets outcome correctly
+void echoDiffEasyWinOutcome(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.numSequences = 1;
+    config.sequenceLength = 2;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false};
+    game->getSession().inputIndex = 0;
+    game->getSession().currentRound = 0;
+
+    game->skipToState(device.pdn, 2);
+    device.pdn->loop();
+
+    // Correct inputs
+    device.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(game->getOutcome().result, MiniGameResult::WON);
+    ASSERT_FALSE(game->getOutcome().hardMode);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Hard mode win sets hardMode flag
+void echoDiffHardWinOutcome(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_HARD;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    config.numSequences = 1;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false, true, false, true, false, true, false};
+    game->getSession().inputIndex = 0;
+    game->getSession().currentRound = 0;
+
+    game->skipToState(device.pdn, 2);
+    device.pdn->loop();
+
+    // Enter all 8 correct inputs
+    for (int i = 0; i < 8; i++) {
+        bool expected = game->getSession().currentSequence[i];
+        if (expected) {
+            device.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        } else {
+            device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+        }
+        device.pdn->loop();
+    }
+
+    for (int i = 0; i < 5; i++) {
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(game->getOutcome().result, MiniGameResult::WON);
+    ASSERT_TRUE(game->getOutcome().hardMode);
+
+    suite->destroyDevice(device);
+}
+
+// Test: Life indicator calculation
+void echoDiffLifeIndicator(SignalEchoDifficultyTestSuite* suite) {
+    ASSERT_EQ(SIGNAL_ECHO_EASY.allowedMistakes, 3);
+    ASSERT_EQ(SIGNAL_ECHO_HARD.allowedMistakes, 1);
+}
+
+// Test: Wrong input advances to next position (locked in)
+void echoDiffWrongInputAdvances(SignalEchoDifficultyTestSuite* suite) {
+    SignalEchoConfig config = SIGNAL_ECHO_EASY;
+    config.rngSeed = 42;
+    config.displaySpeedMs = 10;
+    auto device = suite->createDeviceWithConfig(config);
+    auto* game = dynamic_cast<SignalEcho*>(device.game);
+
+    game->getSession().currentSequence = {true, false, true, false};
+    game->getSession().inputIndex = 0;
+
+    game->skipToState(device.pdn, 2);
+    device.pdn->loop();
+
+    // Wrong press at position 0
+    device.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    device.pdn->loop();
+
+    ASSERT_EQ(game->getSession().inputIndex, 1);
+
+    suite->destroyDevice(device);
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary

- Signal Echo minigame: audio/visual pattern matching (Konami UP #1)
- Full state machine: Intro → Play → Listen → Evaluate → Win/Lose
- EASY/HARD difficulty presets
- LED color: Cyan `{0, 255, 200}`

## Tests

**25 CLI tests** — state transitions, sequence generation, input matching, difficulty configs, win/lose paths

## Merge Order

**2/7** — First minigame, depends on FDN Infrastructure (#2).

Closes #3