### PR TITLE
Color Profile UI: prompt, picker, Idle LED override

### DIFF
--- a/include/cli/cli-device.hpp
+++ b/include/cli/cli-device.hpp
@@ -61,6 +61,8 @@ inline const char* getQuickdrawStateName(int stateId) {
         case 20: return "UploadMatches";
         case 21: return "FdnDetected";
         case 22: return "FdnComplete";
+        case 23: return "ColorProfilePrompt";
+        case 24: return "ColorProfilePicker";
         default: return "Unknown";
     }
 }

--- a/include/game/color-profiles.hpp
+++ b/include/game/color-profiles.hpp
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "device/drivers/light-interface.hpp"
+#include "device/device-types.hpp"
+
+/*
+ * Color profile lookup.
+ *
+ * Each minigame has a unique 9-LED palette that serves as a walking
+ * advertisement on the FDN NPC and as an equippable idle animation
+ * for players who beat hard mode.
+ *
+ * getColorProfileState(gameType) returns a const ref to the LEDState.
+ * Returns a default neutral palette if the game type has no profile.
+ */
+
+// Signal Echo palette — magenta/pink/purple
+const LEDState SIGNAL_ECHO_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,0,255}, {200,0,200}, {255,50,200}, {180,0,255},
+        {255,0,255}, {200,0,200}, {255,50,200}, {180,0,255}, {180,0,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Firewall Decrypt palette — green/cyan hacker theme
+const LEDState FIREWALL_DECRYPT_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {0,255,100}, {0,200,150}, {0,255,200}, {0,150,255},
+        {0,255,100}, {0,200,150}, {0,255,200}, {0,150,255}, {0,150,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Default/neutral palette — warm yellow/white
+const LEDState DEFAULT_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,255,100}, {255,255,200}, {255,255,255}, {200,200,150},
+        {255,255,100}, {255,255,200}, {255,255,255}, {200,200,150}, {200,200,150}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+/*
+ * Look up the LED profile state for a given game type.
+ * Returns DEFAULT_PROFILE_STATE if no specific profile exists.
+ */
+inline const LEDState& getColorProfileState(int gameType) {
+    switch (static_cast<GameType>(gameType)) {
+        case GameType::SIGNAL_ECHO:       return SIGNAL_ECHO_PROFILE_STATE;
+        case GameType::FIREWALL_DECRYPT:  return FIREWALL_DECRYPT_PROFILE_STATE;
+        default:                          return DEFAULT_PROFILE_STATE;
+    }
+}
+
+/*
+ * Get display name for a color profile.
+ */
+inline const char* getColorProfileName(int gameType) {
+    if (gameType < 0) return "DEFAULT";
+    return getGameDisplayName(static_cast<GameType>(gameType));
+}

--- a/src/game/quickdraw-states/color-profile-picker.cpp
+++ b/src/game/quickdraw-states/color-profile-picker.cpp
@@ -1,0 +1,121 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+
+static const char* TAG = "ColorProfilePicker";
+
+ColorProfilePicker::ColorProfilePicker(Player* player, ProgressManager* progressManager) :
+    State(COLOR_PROFILE_PICKER),
+    player(player),
+    progressManager(progressManager)
+{
+}
+
+ColorProfilePicker::~ColorProfilePicker() {
+    player = nullptr;
+    progressManager = nullptr;
+}
+
+void ColorProfilePicker::buildProfileList() {
+    profileList.clear();
+    // Add eligible game profiles
+    for (int gameType : player->getColorProfileEligibility()) {
+        profileList.push_back(gameType);
+    }
+    // Always add DEFAULT as last option
+    profileList.push_back(-1);
+}
+
+void ColorProfilePicker::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    displayIsDirty = false;
+    cursorIndex = 0;
+
+    buildProfileList();
+
+    // Pre-select currently equipped profile
+    int equipped = player->getEquippedColorProfile();
+    for (size_t i = 0; i < profileList.size(); i++) {
+        if (profileList[i] == equipped) {
+            cursorIndex = static_cast<int>(i);
+            break;
+        }
+    }
+
+    LOG_I(TAG, "Color picker opened, %zu profiles available", profileList.size());
+
+    // Primary = scroll, Secondary = confirm
+    parameterizedCallbackFunction scrollCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePicker*>(ctx);
+        self->cursorIndex = (self->cursorIndex + 1) % static_cast<int>(self->profileList.size());
+        self->displayIsDirty = true;
+    };
+
+    parameterizedCallbackFunction confirmCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePicker*>(ctx);
+        int selected = self->profileList[self->cursorIndex];
+        self->player->setEquippedColorProfile(selected);
+        LOG_I(TAG, "Equipped profile: %s", getColorProfileName(selected));
+        if (self->progressManager) {
+            self->progressManager->saveProgress();
+        }
+        self->transitionToIdleState = true;
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(scrollCb, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
+
+    renderUi(PDN);
+}
+
+void ColorProfilePicker::onStateLoop(Device* PDN) {
+    if (displayIsDirty) {
+        renderUi(PDN);
+        displayIsDirty = false;
+    }
+}
+
+void ColorProfilePicker::onStateDismounted(Device* PDN) {
+    profileList.clear();
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+}
+
+bool ColorProfilePicker::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+void ColorProfilePicker::renderUi(Device* PDN) {
+    if (!PDN) return;
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("COLOR PALETTE", 10, 12);
+
+    // Show up to 3 items centered around cursor
+    int listSize = static_cast<int>(profileList.size());
+    int startIdx = cursorIndex;  // Start from cursor, show up to 3
+    int visibleCount = (listSize < 3) ? listSize : 3;
+
+    for (int i = 0; i < visibleCount; i++) {
+        int idx = (startIdx + i) % listSize;
+        int y = 28 + (i * 12);
+        const char* name = getColorProfileName(profileList[idx]);
+
+        if (idx == cursorIndex) {
+            char line[32];
+            snprintf(line, sizeof(line), "> %s", name);
+            PDN->getDisplay()->drawText(line, 5, y);
+        } else {
+            char line[32];
+            snprintf(line, sizeof(line), "  %s", name);
+            PDN->getDisplay()->drawText(line, 5, y);
+        }
+    }
+
+    PDN->getDisplay()->drawText("UP:scroll DOWN:ok", 5, 60);
+    PDN->getDisplay()->render();
+}

--- a/src/game/quickdraw-states/color-profile-prompt.cpp
+++ b/src/game/quickdraw-states/color-profile-prompt.cpp
@@ -1,0 +1,101 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+
+static const char* TAG = "ColorProfilePrompt";
+
+ColorProfilePrompt::ColorProfilePrompt(Player* player, ProgressManager* progressManager) :
+    State(COLOR_PROFILE_PROMPT),
+    player(player),
+    progressManager(progressManager)
+{
+}
+
+ColorProfilePrompt::~ColorProfilePrompt() {
+    player = nullptr;
+    progressManager = nullptr;
+}
+
+void ColorProfilePrompt::onStateMounted(Device* PDN) {
+    transitionToIdleState = false;
+    selectYes = true;
+
+    int gameType = player->getPendingProfileGame();
+    LOG_I(TAG, "Color profile prompt for game type %d", gameType);
+
+    // Set up button callbacks
+    parameterizedCallbackFunction toggleCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePrompt*>(ctx);
+        self->selectYes = !self->selectYes;
+        self->renderUi(nullptr);  // Will be rendered on next loop
+    };
+
+    parameterizedCallbackFunction confirmCb = [](void* ctx) {
+        auto* self = static_cast<ColorProfilePrompt*>(ctx);
+        int gameType = self->player->getPendingProfileGame();
+
+        if (self->selectYes && gameType >= 0) {
+            self->player->setEquippedColorProfile(gameType);
+            LOG_I(TAG, "Equipped color profile: %s",
+                   getColorProfileName(gameType));
+            if (self->progressManager) {
+                self->progressManager->saveProgress();
+            }
+        } else {
+            LOG_I(TAG, "Declined color profile");
+        }
+        self->transitionToIdleState = true;
+    };
+
+    PDN->getPrimaryButton()->setButtonPress(toggleCb, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(confirmCb, this, ButtonInteraction::CLICK);
+
+    // Auto-dismiss timer
+    dismissTimer.setTimer(AUTO_DISMISS_MS);
+
+    renderUi(PDN);
+}
+
+void ColorProfilePrompt::onStateLoop(Device* PDN) {
+    dismissTimer.updateTime();
+    if (dismissTimer.expired()) {
+        LOG_I(TAG, "Auto-dismissed (NO)");
+        transitionToIdleState = true;
+    }
+}
+
+void ColorProfilePrompt::onStateDismounted(Device* PDN) {
+    dismissTimer.invalidate();
+    player->setPendingProfileGame(-1);
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+}
+
+bool ColorProfilePrompt::transitionToIdle() {
+    return transitionToIdleState;
+}
+
+void ColorProfilePrompt::renderUi(Device* PDN) {
+    if (!PDN) return;
+
+    int gameType = player->getPendingProfileGame();
+    const char* gameName = (gameType >= 0) ? getGameDisplayName(static_cast<GameType>(gameType)) : "UNKNOWN";
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("NEW PALETTE!", 15, 12);
+    PDN->getDisplay()->drawText(gameName, 15, 28);
+    PDN->getDisplay()->drawText("EQUIP?", 10, 44);
+
+    if (selectYes) {
+        PDN->getDisplay()->drawText("[YES] NO", 60, 44);
+    } else {
+        PDN->getDisplay()->drawText("YES [NO]", 60, 44);
+    }
+
+    PDN->getDisplay()->drawText("UP:toggle DOWN:ok", 5, 60);
+    PDN->getDisplay()->render();
+}

--- a/src/game/quickdraw-states/fdn-complete-state.cpp
+++ b/src/game/quickdraw-states/fdn-complete-state.cpp
@@ -24,6 +24,7 @@ FdnComplete::~FdnComplete() {
 void FdnComplete::onStateMounted(Device* PDN) {
     LOG_I(TAG, "FDN complete mounted");
     transitionToIdleState = false;
+    transitionToColorPromptState = false;
 
     // Look up the minigame using the game type tracked by FdnDetected
     int lastGameType = player->getLastFdnGameType();
@@ -99,13 +100,22 @@ void FdnComplete::onStateMounted(Device* PDN) {
 void FdnComplete::onStateLoop(Device* PDN) {
     displayTimer.updateTime();
     if (displayTimer.expired()) {
-        transitionToIdleState = true;
+        // Route to color prompt if hard mode was won and profile is pending
+        if (player->getPendingProfileGame() >= 0) {
+            transitionToColorPromptState = true;
+        } else {
+            transitionToIdleState = true;
+        }
     }
 }
 
 void FdnComplete::onStateDismounted(Device* PDN) {
     displayTimer.invalidate();
     player->clearPendingChallenge();
+}
+
+bool FdnComplete::transitionToColorPrompt() {
+    return transitionToColorPromptState;
 }
 
 bool FdnComplete::transitionToIdle() {

--- a/src/game/quickdraw.cpp
+++ b/src/game/quickdraw.cpp
@@ -55,6 +55,8 @@ void Quickdraw::populateStateMap() {
 
     FdnDetected* fdnDetected = new FdnDetected(player);
     FdnComplete* fdnComplete = new FdnComplete(player, progressManager);
+    ColorProfilePrompt* colorProfilePrompt = new ColorProfilePrompt(player, progressManager);
+    ColorProfilePicker* colorProfilePicker = new ColorProfilePicker(player, progressManager);
 
     playerRegistration->addTransition(
         new StateTransition(
@@ -113,6 +115,11 @@ void Quickdraw::populateStateMap() {
 
     idle->addTransition(
         new StateTransition(
+            std::bind(&Idle::transitionToColorPicker, idle),
+            colorProfilePicker));
+
+    idle->addTransition(
+        new StateTransition(
             std::bind(&Idle::isFdnDetected, idle),
             fdnDetected));
 
@@ -133,7 +140,22 @@ void Quickdraw::populateStateMap() {
 
     fdnComplete->addTransition(
         new StateTransition(
+            std::bind(&FdnComplete::transitionToColorPrompt, fdnComplete),
+            colorProfilePrompt));
+
+    fdnComplete->addTransition(
+        new StateTransition(
             std::bind(&FdnComplete::transitionToIdle, fdnComplete),
+            idle));
+
+    colorProfilePrompt->addTransition(
+        new StateTransition(
+            std::bind(&ColorProfilePrompt::transitionToIdle, colorProfilePrompt),
+            idle));
+
+    colorProfilePicker->addTransition(
+        new StateTransition(
+            std::bind(&ColorProfilePicker::transitionToIdle, colorProfilePicker),
             idle));
 
     handshakeInitiate->addTransition(
@@ -264,6 +286,8 @@ void Quickdraw::populateStateMap() {
     stateMap.push_back(sleep);
     stateMap.push_back(fdnDetected);
     stateMap.push_back(fdnComplete);
+    stateMap.push_back(colorProfilePrompt);
+    stateMap.push_back(colorProfilePicker);
 }
 
 Image Quickdraw::getImageForAllegiance(Allegiance allegiance, ImageType whichImage) {

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -17,6 +17,7 @@
 #include "signal-echo-tests.hpp"
 #include "fdn-integration-tests.hpp"
 #include "progression-core-tests.hpp"
+#include "color-profile-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -812,6 +813,114 @@ TEST_F(KonamiCommandTestSuite, ShowsProgress) {
 
 TEST_F(KonamiCommandTestSuite, SetsProgress) {
     konamiCommandSetsProgress(this);
+}
+
+// ============================================
+// COLOR PROFILE LOOKUP TESTS
+// ============================================
+
+TEST_F(ColorProfileLookupTestSuite, SignalEcho) {
+    colorProfileLookupSignalEcho(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, FirewallDecrypt) {
+    colorProfileLookupFirewallDecrypt(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, Default) {
+    colorProfileLookupDefault(this);
+}
+
+TEST_F(ColorProfileLookupTestSuite, Names) {
+    colorProfileLookupNames(this);
+}
+
+// ============================================
+// COLOR PROFILE PROMPT TESTS
+// ============================================
+
+TEST_F(ColorProfilePromptTestSuite, YesEquips) {
+    colorProfilePromptYesEquips(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, NoDoesNotEquip) {
+    colorProfilePromptNoDoesNotEquip(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, AutoDismiss) {
+    colorProfilePromptAutoDismiss(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, ShowsDisplay) {
+    colorProfilePromptShowsDisplay(this);
+}
+
+TEST_F(ColorProfilePromptTestSuite, ClearsPending) {
+    colorProfilePromptClearsPending(this);
+}
+
+// ============================================
+// COLOR PROFILE PICKER TESTS
+// ============================================
+
+TEST_F(ColorProfilePickerTestSuite, ShowsHeader) {
+    colorProfilePickerShowsHeader(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, ScrollWraps) {
+    colorProfilePickerScrollWraps(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, SelectDefault) {
+    colorProfilePickerSelectDefault(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, TransitionsToIdle) {
+    colorProfilePickerTransitionsToIdle(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, PreselectsEquipped) {
+    colorProfilePickerPreselectsEquipped(this);
+}
+
+// ============================================
+// FDN COMPLETE ROUTING TESTS
+// ============================================
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToPromptOnHardWin) {
+    fdnCompleteRoutesToPromptOnHardWin(this);
+}
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToIdleOnEasyWin) {
+    fdnCompleteRoutesToIdleOnEasyWin(this);
+}
+
+TEST_F(FdnCompleteRoutingTestSuite, RoutesToIdleOnLoss) {
+    fdnCompleteRoutesToIdleOnLoss(this);
+}
+
+// ============================================
+// IDLE COLOR PICKER ENTRY TESTS
+// ============================================
+
+TEST_F(IdleColorPickerTestSuite, LongPressEntersPicker) {
+    idleLongPressEntersPicker(this);
+}
+
+TEST_F(IdleColorPickerTestSuite, LongPressNoPickerWithoutEligibility) {
+    idleLongPressNoPickerWithoutEligibility(this);
+}
+
+// ============================================
+// STATE NAME TESTS
+// ============================================
+
+TEST_F(StateNameTestSuite, ColorProfilePrompt) {
+    stateNameColorProfilePrompt(this);
+}
+
+TEST_F(StateNameTestSuite, ColorProfilePicker) {
+    stateNameColorProfilePicker(this);
 }
 
 // ============================================

--- a/test/test_cli/color-profile-tests.hpp
+++ b/test/test_cli/color-profile-tests.hpp
@@ -1,0 +1,456 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "game/color-profiles.hpp"
+#include "game/progress-manager.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+
+using namespace cli;
+
+// ============================================
+// COLOR PROFILE LOOKUP TEST SUITE
+// ============================================
+
+class ColorProfileLookupTestSuite : public testing::Test {};
+
+// Test: getColorProfileState returns Signal Echo palette
+void colorProfileLookupSignalEcho(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(static_cast<int>(GameType::SIGNAL_ECHO));
+    // Signal Echo palette: first LED should be magenta (255,0,255)
+    ASSERT_EQ(state.leftLights[0].color.red, 255);
+    ASSERT_EQ(state.leftLights[0].color.green, 0);
+    ASSERT_EQ(state.leftLights[0].color.blue, 255);
+}
+
+// Test: getColorProfileState returns Firewall Decrypt palette
+void colorProfileLookupFirewallDecrypt(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(static_cast<int>(GameType::FIREWALL_DECRYPT));
+    // Firewall Decrypt palette: first LED should be green (0,255,100)
+    ASSERT_EQ(state.leftLights[0].color.red, 0);
+    ASSERT_EQ(state.leftLights[0].color.green, 255);
+    ASSERT_EQ(state.leftLights[0].color.blue, 100);
+}
+
+// Test: getColorProfileState returns default for unknown game type
+void colorProfileLookupDefault(ColorProfileLookupTestSuite* /*suite*/) {
+    const LEDState& state = getColorProfileState(-1);
+    // Default palette: warm yellow (255,255,100)
+    ASSERT_EQ(state.leftLights[0].color.red, 255);
+    ASSERT_EQ(state.leftLights[0].color.green, 255);
+    ASSERT_EQ(state.leftLights[0].color.blue, 100);
+}
+
+// Test: getColorProfileName returns correct names
+void colorProfileLookupNames(ColorProfileLookupTestSuite* /*suite*/) {
+    ASSERT_STREQ(getColorProfileName(-1), "DEFAULT");
+    const char* echoName = getColorProfileName(static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_NE(echoName, nullptr);
+    ASSERT_STRNE(echoName, "DEFAULT");
+}
+
+// ============================================
+// COLOR PROFILE PROMPT TEST SUITE
+// ============================================
+
+class ColorProfilePromptTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToPrompt() {
+        // Set up player state: pending profile game set
+        device_.player->setPendingProfileGame(static_cast<int>(GameType::SIGNAL_ECHO));
+        device_.game->skipToState(device_.pdn, 23);  // ColorProfilePrompt
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: YES equips the color profile
+void colorProfilePromptYesEquips(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Default selection is YES. Press secondary to confirm.
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Toggling to NO then confirming does NOT equip
+void colorProfilePromptNoDoesNotEquip(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Toggle to NO (primary), then confirm (secondary)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Auto-dismiss after timeout defaults to NO
+void colorProfilePromptAutoDismiss(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+
+    // Advance past 10s auto-dismiss
+    suite->tickWithTime(20, 600);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Display shows EQUIP text and YES/NO
+void colorProfilePromptShowsDisplay(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundEquip = false;
+    bool foundYesNo = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("EQUIP?") != std::string::npos) foundEquip = true;
+        if (entry.find("YES") != std::string::npos) foundYesNo = true;
+    }
+    ASSERT_TRUE(foundEquip);
+    ASSERT_TRUE(foundYesNo);
+}
+
+// Test: Clears pendingProfileGame on dismount
+void colorProfilePromptClearsPending(ColorProfilePromptTestSuite* suite) {
+    suite->skipToPrompt();
+
+    suite->device_.player->setPendingProfileGame(7);
+    // Confirm YES to transition away
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(), -1);
+}
+
+// ============================================
+// COLOR PROFILE PICKER TEST SUITE
+// ============================================
+
+class ColorProfilePickerTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToPicker() {
+        // Add some eligible profiles
+        device_.player->addColorProfileEligibility(static_cast<int>(GameType::SIGNAL_ECHO));
+        device_.game->skipToState(device_.pdn, 24);  // ColorProfilePicker
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Picker shows COLOR PALETTE header
+void colorProfilePickerShowsHeader(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PICKER);
+
+    auto& textHistory = suite->device_.displayDriver->getTextHistory();
+    bool foundHeader = false;
+    for (const auto& entry : textHistory) {
+        if (entry.find("COLOR PALETTE") != std::string::npos) foundHeader = true;
+    }
+    ASSERT_TRUE(foundHeader);
+}
+
+// Test: Scrolling wraps around profile list
+void colorProfilePickerScrollWraps(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    // profileList = [SIGNAL_ECHO(7), DEFAULT(-1)]
+    // Pre-select: equipped=-1 → cursorIndex=1 (DEFAULT)
+    // Scroll once → wraps to index 0 (SIGNAL_ECHO)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Scroll again → back to index 1 (DEFAULT)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Scroll third time → wraps to index 0 (SIGNAL_ECHO)
+    suite->device_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(1);
+
+    // Confirm — should equip SIGNAL_ECHO
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// Test: Selecting DEFAULT equips -1
+void colorProfilePickerSelectDefault(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    // profileList = [SIGNAL_ECHO(7), DEFAULT(-1)]
+    // Pre-select: equipped=-1 → cursorIndex=1 (DEFAULT)
+    // Already on DEFAULT, just confirm
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(), -1);
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Picker transitions back to Idle on confirm
+void colorProfilePickerTransitionsToIdle(ColorProfilePickerTestSuite* suite) {
+    suite->skipToPicker();
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Pre-selects currently equipped profile
+void colorProfilePickerPreselectsEquipped(ColorProfilePickerTestSuite* suite) {
+    // Equip Signal Echo before entering picker
+    suite->device_.player->setEquippedColorProfile(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->skipToPicker();
+
+    // Confirm immediately (should keep SIGNAL_ECHO since it was pre-selected)
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->device_.player->getEquippedColorProfile(),
+              static_cast<int>(GameType::SIGNAL_ECHO));
+}
+
+// ============================================
+// FDN COMPLETE → COLOR PROMPT ROUTING
+// ============================================
+
+class FdnCompleteRoutingTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            device_.clockDriver->advance(delayMs);
+            device_.pdn->loop();
+        }
+    }
+
+    void setupWinOutcome(bool hardMode = false) {
+        auto* echo = dynamic_cast<MiniGame*>(
+            device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+        MiniGameOutcome outcome;
+        outcome.result = MiniGameResult::WON;
+        outcome.score = 100;
+        outcome.hardMode = hardMode;
+        echo->setOutcome(outcome);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Hard win routes to ColorProfilePrompt
+void fdnCompleteRoutesToPromptOnHardWin(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->setupWinOutcome(true);  // hard mode
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    // pendingProfileGame should be set
+    ASSERT_GE(suite->device_.player->getPendingProfileGame(), 0);
+
+    // Wait for display timer
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PROMPT);
+}
+
+// Test: Easy win routes to Idle (no color prompt)
+void fdnCompleteRoutesToIdleOnEasyWin(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->setupWinOutcome(false);  // easy mode
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    // pendingProfileGame should NOT be set
+    ASSERT_EQ(suite->device_.player->getPendingProfileGame(), -1);
+
+    // Wait for display timer
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// Test: Loss routes to Idle (no color prompt)
+void fdnCompleteRoutesToIdleOnLoss(FdnCompleteRoutingTestSuite* suite) {
+    suite->device_.player->setLastFdnGameType(static_cast<int>(GameType::SIGNAL_ECHO));
+
+    auto* echo = dynamic_cast<MiniGame*>(
+        suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID)));
+    MiniGameOutcome outcome;
+    outcome.result = MiniGameResult::LOST;
+    outcome.score = 50;
+    outcome.hardMode = true;
+    echo->setOutcome(outcome);
+
+    suite->device_.player->setPendingChallenge("fdn:7:6");
+
+    suite->device_.game->skipToState(suite->device_.pdn, 22);  // FdnComplete
+    suite->tick(1);
+
+    suite->tickWithTime(10, 400);
+
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// ============================================
+// IDLE COLOR PICKER ENTRY TEST SUITE
+// ============================================
+
+class IdleColorPickerTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        device_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(device_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(device_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            device_.pdn->loop();
+        }
+    }
+
+    void skipToIdle() {
+        device_.game->skipToState(device_.pdn, 7);  // Idle
+        tick(1);
+    }
+
+    int getStateId() {
+        return device_.game->getCurrentState()->getStateId();
+    }
+
+    DeviceInstance device_;
+};
+
+// Test: Long press secondary enters ColorProfilePicker when eligible profiles exist
+void idleLongPressEntersPicker(IdleColorPickerTestSuite* suite) {
+    suite->device_.player->addColorProfileEligibility(static_cast<int>(GameType::SIGNAL_ECHO));
+    suite->skipToIdle();
+    ASSERT_EQ(suite->getStateId(), IDLE);
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tick(2);
+
+    ASSERT_EQ(suite->getStateId(), COLOR_PROFILE_PICKER);
+}
+
+// Test: Long press does NOT enter picker when no eligible profiles
+void idleLongPressNoPickerWithoutEligibility(IdleColorPickerTestSuite* suite) {
+    suite->skipToIdle();
+    ASSERT_EQ(suite->getStateId(), IDLE);
+
+    suite->device_.secondaryButtonDriver->execCallback(ButtonInteraction::LONG_PRESS);
+    suite->tick(2);
+
+    // Should stay in Idle since no eligible profiles
+    ASSERT_EQ(suite->getStateId(), IDLE);
+}
+
+// ============================================
+// STATE NAME MAPPING TESTS
+// ============================================
+
+class StateNameTestSuite : public testing::Test {};
+
+void stateNameColorProfilePrompt(StateNameTestSuite* /*suite*/) {
+    ASSERT_STREQ(getQuickdrawStateName(23), "ColorProfilePrompt");
+}
+
+void stateNameColorProfilePicker(StateNameTestSuite* /*suite*/) {
+    ASSERT_STREQ(getQuickdrawStateName(24), "ColorProfilePicker");
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary

- Color profile reward system: earned after HARD mode win
- Selection prompt UI on OLED
- Color picker with LED preview
- Idle state LED override with chosen profile

## Tests

**21 CLI tests** — prompt display, picker navigation, profile application, LED override in Idle

## Merge Order

**5/7** — UI layer, depends on Progression Core (#5).

Closes #6