### PR TITLE
Register 5 stub minigames in FDN system (#30)

### DIFF
--- a/include/device/device-types.hpp
+++ b/include/device/device-types.hpp
@@ -87,7 +87,12 @@ inline const char* getKonamiButtonName(KonamiButton button) {
 inline int getAppIdForGame(GameType type) {
     switch (type) {
         case GameType::SIGNAL_ECHO:       return 2;  // SIGNAL_ECHO_APP_ID
-        case GameType::FIREWALL_DECRYPT:  return 3;  // FIREWALL_DECRYPT_APP_ID (future)
+        case GameType::FIREWALL_DECRYPT:  return 3;  // FIREWALL_DECRYPT_APP_ID
+        case GameType::GHOST_RUNNER:      return 4;  // GHOST_RUNNER_APP_ID
+        case GameType::SPIKE_VECTOR:      return 5;  // SPIKE_VECTOR_APP_ID
+        case GameType::CIPHER_PATH:       return 6;  // CIPHER_PATH_APP_ID
+        case GameType::EXPLOIT_SEQUENCER: return 7;  // EXPLOIT_SEQUENCER_APP_ID
+        case GameType::BREACH_DEFENSE:    return 8;  // BREACH_DEFENSE_APP_ID
         default:                          return -1;
     }
 }

--- a/include/game/breach-defense/breach-defense-states.hpp
+++ b/include/game/breach-defense/breach-defense-states.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class BreachDefense;
+
+/*
+ * Breach Defense state IDs — offset to 700+ to avoid collisions.
+ */
+enum BreachDefenseStateId {
+    BREACH_INTRO = 700,
+    BREACH_WIN   = 701,
+    BREACH_LOSE  = 702,
+};
+
+/*
+ * BreachDefenseIntro — Title screen. Shows "BREACH DEFENSE" and subtitle.
+ * Auto-transitions to BreachDefenseWin after INTRO_DURATION_MS (stub behavior).
+ */
+class BreachDefenseIntro : public State {
+public:
+    explicit BreachDefenseIntro(BreachDefense* game);
+    ~BreachDefenseIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+
+private:
+    BreachDefense* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToWinState = false;
+};
+
+/*
+ * BreachDefenseWin — Victory screen. Shows "BREACH BLOCKED".
+ * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class BreachDefenseWin : public State {
+public:
+    explicit BreachDefenseWin(BreachDefense* game);
+    ~BreachDefenseWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    BreachDefense* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * BreachDefenseLose — Defeat screen. Shows "BREACH OPEN".
+ * Sets outcome to LOST. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class BreachDefenseLose : public State {
+public:
+    explicit BreachDefenseLose(BreachDefense* game);
+    ~BreachDefenseLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    BreachDefense* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/breach-defense/breach-defense.hpp
+++ b/include/game/breach-defense/breach-defense.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "game/breach-defense/breach-defense-states.hpp"
+
+constexpr int BREACH_DEFENSE_APP_ID = 8;
+
+struct BreachDefenseConfig {
+    int timeLimitMs = 0;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+struct BreachDefenseSession {
+    int score = 0;
+    void reset() { score = 0; }
+};
+
+inline BreachDefenseConfig makeBreachDefenseEasyConfig() {
+    BreachDefenseConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline BreachDefenseConfig makeBreachDefenseHardConfig() {
+    BreachDefenseConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const BreachDefenseConfig BREACH_DEFENSE_EASY = makeBreachDefenseEasyConfig();
+const BreachDefenseConfig BREACH_DEFENSE_HARD = makeBreachDefenseHardConfig();
+
+/*
+ * Breach Defense — stub minigame.
+ *
+ * Placeholder implementation: shows intro, auto-wins after 2s.
+ * Phase 2 replaces with real fortress-defense mechanics.
+ *
+ * In managed mode (via FDN), terminal states call
+ * Device::returnToPreviousApp(). In standalone mode, loops to intro.
+ */
+class BreachDefense : public MiniGame {
+public:
+    explicit BreachDefense(BreachDefenseConfig config) :
+        MiniGame(BREACH_DEFENSE_APP_ID, GameType::BREACH_DEFENSE, "BREACH DEFENSE"),
+        config(config)
+    {
+    }
+
+    void populateStateMap() override;
+    void resetGame() override;
+
+    BreachDefenseConfig& getConfig() { return config; }
+    BreachDefenseSession& getSession() { return session; }
+
+private:
+    BreachDefenseConfig config;
+    BreachDefenseSession session;
+};

--- a/include/game/cipher-path/cipher-path-states.hpp
+++ b/include/game/cipher-path/cipher-path-states.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class CipherPath;
+
+/*
+ * Cipher Path state IDs — offset to 500+ to avoid collisions.
+ */
+enum CipherPathStateId {
+    CIPHER_INTRO = 500,
+    CIPHER_WIN   = 501,
+    CIPHER_LOSE  = 502,
+};
+
+/*
+ * CipherPathIntro — Title screen. Shows "CIPHER PATH" and subtitle.
+ * Auto-transitions to CipherPathWin after INTRO_DURATION_MS (stub behavior).
+ */
+class CipherPathIntro : public State {
+public:
+    explicit CipherPathIntro(CipherPath* game);
+    ~CipherPathIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+
+private:
+    CipherPath* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToWinState = false;
+};
+
+/*
+ * CipherPathWin — Victory screen. Shows "PATH DECODED".
+ * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class CipherPathWin : public State {
+public:
+    explicit CipherPathWin(CipherPath* game);
+    ~CipherPathWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    CipherPath* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * CipherPathLose — Defeat screen. Shows "PATH LOST".
+ * Sets outcome to LOST. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class CipherPathLose : public State {
+public:
+    explicit CipherPathLose(CipherPath* game);
+    ~CipherPathLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    CipherPath* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/cipher-path/cipher-path.hpp
+++ b/include/game/cipher-path/cipher-path.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "game/cipher-path/cipher-path-states.hpp"
+
+constexpr int CIPHER_PATH_APP_ID = 6;
+
+struct CipherPathConfig {
+    int timeLimitMs = 0;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+struct CipherPathSession {
+    int score = 0;
+    void reset() { score = 0; }
+};
+
+inline CipherPathConfig makeCipherPathEasyConfig() {
+    CipherPathConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline CipherPathConfig makeCipherPathHardConfig() {
+    CipherPathConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const CipherPathConfig CIPHER_PATH_EASY = makeCipherPathEasyConfig();
+const CipherPathConfig CIPHER_PATH_HARD = makeCipherPathHardConfig();
+
+/*
+ * Cipher Path — stub minigame.
+ *
+ * Placeholder implementation: shows intro, auto-wins after 2s.
+ * Phase 2 replaces with real pathfinding mechanics.
+ *
+ * In managed mode (via FDN), terminal states call
+ * Device::returnToPreviousApp(). In standalone mode, loops to intro.
+ */
+class CipherPath : public MiniGame {
+public:
+    explicit CipherPath(CipherPathConfig config) :
+        MiniGame(CIPHER_PATH_APP_ID, GameType::CIPHER_PATH, "CIPHER PATH"),
+        config(config)
+    {
+    }
+
+    void populateStateMap() override;
+    void resetGame() override;
+
+    CipherPathConfig& getConfig() { return config; }
+    CipherPathSession& getSession() { return session; }
+
+private:
+    CipherPathConfig config;
+    CipherPathSession session;
+};

--- a/include/game/color-profiles.hpp
+++ b/include/game/color-profiles.hpp
@@ -42,6 +42,76 @@ const LEDState FIREWALL_DECRYPT_PROFILE_STATE = [](){
     return state;
 }();
 
+// Ghost Runner palette — cyan/white/pale blue
+const LEDState GHOST_RUNNER_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {0,255,255}, {100,255,255}, {200,255,255}, {150,200,255},
+        {0,255,255}, {100,255,255}, {200,255,255}, {150,200,255}, {150,200,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Spike Vector palette — yellow/orange/red
+const LEDState SPIKE_VECTOR_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,200,0}, {255,150,0}, {255,100,0}, {255,50,0},
+        {255,200,0}, {255,150,0}, {255,100,0}, {255,50,0}, {255,50,0}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Cipher Path palette — green/lime/teal
+const LEDState CIPHER_PATH_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {0,255,50}, {50,255,100}, {0,200,80}, {0,255,150},
+        {0,255,50}, {50,255,100}, {0,200,80}, {0,255,150}, {0,255,150}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Exploit Sequencer palette — red/dark purple/crimson
+const LEDState EXPLOIT_SEQUENCER_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {255,0,50}, {200,0,100}, {180,0,80}, {150,0,60},
+        {255,0,50}, {200,0,100}, {180,0,80}, {150,0,60}, {150,0,60}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
+// Breach Defense palette — blue/silver/white
+const LEDState BREACH_DEFENSE_PROFILE_STATE = [](){
+    LEDState state;
+    LEDColor colors[9] = {
+        {0,100,255}, {50,150,255}, {100,200,255}, {200,200,255},
+        {0,100,255}, {50,150,255}, {100,200,255}, {200,200,255}, {200,200,255}
+    };
+    for (int i = 0; i < 9; i++) {
+        state.leftLights[i] = LEDState::SingleLEDState(colors[i], 65);
+        state.rightLights[i] = LEDState::SingleLEDState(colors[i], 65);
+    }
+    return state;
+}();
+
 // Default/neutral palette — warm yellow/white
 const LEDState DEFAULT_PROFILE_STATE = [](){
     LEDState state;
@@ -64,6 +134,11 @@ inline const LEDState& getColorProfileState(int gameType) {
     switch (static_cast<GameType>(gameType)) {
         case GameType::SIGNAL_ECHO:       return SIGNAL_ECHO_PROFILE_STATE;
         case GameType::FIREWALL_DECRYPT:  return FIREWALL_DECRYPT_PROFILE_STATE;
+        case GameType::GHOST_RUNNER:      return GHOST_RUNNER_PROFILE_STATE;
+        case GameType::SPIKE_VECTOR:      return SPIKE_VECTOR_PROFILE_STATE;
+        case GameType::CIPHER_PATH:       return CIPHER_PATH_PROFILE_STATE;
+        case GameType::EXPLOIT_SEQUENCER: return EXPLOIT_SEQUENCER_PROFILE_STATE;
+        case GameType::BREACH_DEFENSE:    return BREACH_DEFENSE_PROFILE_STATE;
         default:                          return DEFAULT_PROFILE_STATE;
     }
 }

--- a/include/game/exploit-sequencer/exploit-sequencer-states.hpp
+++ b/include/game/exploit-sequencer/exploit-sequencer-states.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class ExploitSequencer;
+
+/*
+ * Exploit Sequencer state IDs — offset to 600+ to avoid collisions.
+ */
+enum ExploitSequencerStateId {
+    EXPLOIT_INTRO = 600,
+    EXPLOIT_WIN   = 601,
+    EXPLOIT_LOSE  = 602,
+};
+
+/*
+ * ExploitSequencerIntro — Title screen. Shows "EXPLOIT SEQUENCER" and subtitle.
+ * Auto-transitions to ExploitSequencerWin after INTRO_DURATION_MS (stub behavior).
+ */
+class ExploitSequencerIntro : public State {
+public:
+    explicit ExploitSequencerIntro(ExploitSequencer* game);
+    ~ExploitSequencerIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+
+private:
+    ExploitSequencer* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToWinState = false;
+};
+
+/*
+ * ExploitSequencerWin — Victory screen. Shows "EXPLOIT DONE".
+ * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class ExploitSequencerWin : public State {
+public:
+    explicit ExploitSequencerWin(ExploitSequencer* game);
+    ~ExploitSequencerWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    ExploitSequencer* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * ExploitSequencerLose — Defeat screen. Shows "EXPLOIT FAILED".
+ * Sets outcome to LOST. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class ExploitSequencerLose : public State {
+public:
+    explicit ExploitSequencerLose(ExploitSequencer* game);
+    ~ExploitSequencerLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    ExploitSequencer* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/exploit-sequencer/exploit-sequencer.hpp
+++ b/include/game/exploit-sequencer/exploit-sequencer.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+
+constexpr int EXPLOIT_SEQUENCER_APP_ID = 7;
+
+struct ExploitSequencerConfig {
+    int timeLimitMs = 0;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+struct ExploitSequencerSession {
+    int score = 0;
+    void reset() { score = 0; }
+};
+
+inline ExploitSequencerConfig makeExploitSequencerEasyConfig() {
+    ExploitSequencerConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline ExploitSequencerConfig makeExploitSequencerHardConfig() {
+    ExploitSequencerConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const ExploitSequencerConfig EXPLOIT_SEQUENCER_EASY = makeExploitSequencerEasyConfig();
+const ExploitSequencerConfig EXPLOIT_SEQUENCER_HARD = makeExploitSequencerHardConfig();
+
+/*
+ * Exploit Sequencer — stub minigame.
+ *
+ * Placeholder implementation: shows intro, auto-wins after 2s.
+ * Phase 2 replaces with real exploit-chaining mechanics.
+ *
+ * In managed mode (via FDN), terminal states call
+ * Device::returnToPreviousApp(). In standalone mode, loops to intro.
+ */
+class ExploitSequencer : public MiniGame {
+public:
+    explicit ExploitSequencer(ExploitSequencerConfig config) :
+        MiniGame(EXPLOIT_SEQUENCER_APP_ID, GameType::EXPLOIT_SEQUENCER, "EXPLOIT SEQUENCER"),
+        config(config)
+    {
+    }
+
+    void populateStateMap() override;
+    void resetGame() override;
+
+    ExploitSequencerConfig& getConfig() { return config; }
+    ExploitSequencerSession& getSession() { return session; }
+
+private:
+    ExploitSequencerConfig config;
+    ExploitSequencerSession session;
+};

--- a/include/game/ghost-runner/ghost-runner-states.hpp
+++ b/include/game/ghost-runner/ghost-runner-states.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class GhostRunner;
+
+/*
+ * Ghost Runner state IDs — offset to 300+ to avoid collisions.
+ */
+enum GhostRunnerStateId {
+    GHOST_INTRO = 300,
+    GHOST_WIN   = 301,
+    GHOST_LOSE  = 302,
+};
+
+/*
+ * GhostRunnerIntro — Title screen. Shows "GHOST RUNNER" and subtitle.
+ * Auto-transitions to GhostRunnerWin after INTRO_DURATION_MS (stub behavior).
+ */
+class GhostRunnerIntro : public State {
+public:
+    explicit GhostRunnerIntro(GhostRunner* game);
+    ~GhostRunnerIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+
+private:
+    GhostRunner* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToWinState = false;
+};
+
+/*
+ * GhostRunnerWin — Victory screen. Shows "RUN COMPLETE".
+ * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class GhostRunnerWin : public State {
+public:
+    explicit GhostRunnerWin(GhostRunner* game);
+    ~GhostRunnerWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    GhostRunner* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * GhostRunnerLose — Defeat screen. Shows "GHOST CAUGHT".
+ * Sets outcome to LOST. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class GhostRunnerLose : public State {
+public:
+    explicit GhostRunnerLose(GhostRunner* game);
+    ~GhostRunnerLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    GhostRunner* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/ghost-runner/ghost-runner.hpp
+++ b/include/game/ghost-runner/ghost-runner.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "game/ghost-runner/ghost-runner-states.hpp"
+
+constexpr int GHOST_RUNNER_APP_ID = 4;
+
+struct GhostRunnerConfig {
+    int timeLimitMs = 0;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+struct GhostRunnerSession {
+    int score = 0;
+    void reset() { score = 0; }
+};
+
+inline GhostRunnerConfig makeGhostRunnerEasyConfig() {
+    GhostRunnerConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline GhostRunnerConfig makeGhostRunnerHardConfig() {
+    GhostRunnerConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const GhostRunnerConfig GHOST_RUNNER_EASY = makeGhostRunnerEasyConfig();
+const GhostRunnerConfig GHOST_RUNNER_HARD = makeGhostRunnerHardConfig();
+
+/*
+ * Ghost Runner — stub minigame.
+ *
+ * Placeholder implementation: shows intro, auto-wins after 2s.
+ * Phase 2 replaces with real ghost-running mechanics.
+ *
+ * In managed mode (via FDN), terminal states call
+ * Device::returnToPreviousApp(). In standalone mode, loops to intro.
+ */
+class GhostRunner : public MiniGame {
+public:
+    explicit GhostRunner(GhostRunnerConfig config) :
+        MiniGame(GHOST_RUNNER_APP_ID, GameType::GHOST_RUNNER, "GHOST RUNNER"),
+        config(config)
+    {
+    }
+
+    void populateStateMap() override;
+    void resetGame() override;
+
+    GhostRunnerConfig& getConfig() { return config; }
+    GhostRunnerSession& getSession() { return session; }
+
+private:
+    GhostRunnerConfig config;
+    GhostRunnerSession session;
+};

--- a/include/game/spike-vector/spike-vector-states.hpp
+++ b/include/game/spike-vector/spike-vector-states.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include "state/state.hpp"
+#include "utils/simple-timer.hpp"
+
+class SpikeVector;
+
+/*
+ * Spike Vector state IDs — offset to 400+ to avoid collisions.
+ */
+enum SpikeVectorStateId {
+    SPIKE_INTRO = 400,
+    SPIKE_WIN   = 401,
+    SPIKE_LOSE  = 402,
+};
+
+/*
+ * SpikeVectorIntro — Title screen. Shows "SPIKE VECTOR" and subtitle.
+ * Auto-transitions to SpikeVectorWin after INTRO_DURATION_MS (stub behavior).
+ */
+class SpikeVectorIntro : public State {
+public:
+    explicit SpikeVectorIntro(SpikeVector* game);
+    ~SpikeVectorIntro() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToWin();
+
+private:
+    SpikeVector* game;
+    SimpleTimer introTimer;
+    static constexpr int INTRO_DURATION_MS = 2000;
+    bool transitionToWinState = false;
+};
+
+/*
+ * SpikeVectorWin — Victory screen. Shows "VECTOR CLEAR".
+ * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class SpikeVectorWin : public State {
+public:
+    explicit SpikeVectorWin(SpikeVector* game);
+    ~SpikeVectorWin() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SpikeVector* game;
+    SimpleTimer winTimer;
+    static constexpr int WIN_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};
+
+/*
+ * SpikeVectorLose — Defeat screen. Shows "SPIKE IMPACT".
+ * Sets outcome to LOST. In standalone mode, transitions back to Intro.
+ * In managed mode, calls Device::returnToPreviousApp().
+ */
+class SpikeVectorLose : public State {
+public:
+    explicit SpikeVectorLose(SpikeVector* game);
+    ~SpikeVectorLose() override;
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+    bool transitionToIntro();
+    bool isTerminalState() override;
+
+private:
+    SpikeVector* game;
+    SimpleTimer loseTimer;
+    static constexpr int LOSE_DISPLAY_MS = 3000;
+    bool transitionToIntroState = false;
+};

--- a/include/game/spike-vector/spike-vector.hpp
+++ b/include/game/spike-vector/spike-vector.hpp
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "game/minigame.hpp"
+#include "game/spike-vector/spike-vector-states.hpp"
+
+constexpr int SPIKE_VECTOR_APP_ID = 5;
+
+struct SpikeVectorConfig {
+    int timeLimitMs = 0;
+    unsigned long rngSeed = 0;
+    bool managedMode = false;
+};
+
+struct SpikeVectorSession {
+    int score = 0;
+    void reset() { score = 0; }
+};
+
+inline SpikeVectorConfig makeSpikeVectorEasyConfig() {
+    SpikeVectorConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+inline SpikeVectorConfig makeSpikeVectorHardConfig() {
+    SpikeVectorConfig c;
+    c.timeLimitMs = 0;
+    c.rngSeed = 0;
+    c.managedMode = false;
+    return c;
+}
+
+const SpikeVectorConfig SPIKE_VECTOR_EASY = makeSpikeVectorEasyConfig();
+const SpikeVectorConfig SPIKE_VECTOR_HARD = makeSpikeVectorHardConfig();
+
+/*
+ * Spike Vector — stub minigame.
+ *
+ * Placeholder implementation: shows intro, auto-wins after 2s.
+ * Phase 2 replaces with real spike-dodging mechanics.
+ *
+ * In managed mode (via FDN), terminal states call
+ * Device::returnToPreviousApp(). In standalone mode, loops to intro.
+ */
+class SpikeVector : public MiniGame {
+public:
+    explicit SpikeVector(SpikeVectorConfig config) :
+        MiniGame(SPIKE_VECTOR_APP_ID, GameType::SPIKE_VECTOR, "SPIKE VECTOR"),
+        config(config)
+    {
+    }
+
+    void populateStateMap() override;
+    void resetGame() override;
+
+    SpikeVectorConfig& getConfig() { return config; }
+    SpikeVectorSession& getSession() { return session; }
+
+private:
+    SpikeVectorConfig config;
+    SpikeVectorSession session;
+};

--- a/src/game/breach-defense/breach-defense-intro.cpp
+++ b/src/game/breach-defense/breach-defense-intro.cpp
@@ -1,0 +1,48 @@
+#include "game/breach-defense/breach-defense-states.hpp"
+#include "game/breach-defense/breach-defense.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "BreachDefenseIntro";
+
+BreachDefenseIntro::BreachDefenseIntro(BreachDefense* game) : State(BREACH_INTRO) {
+    this->game = game;
+}
+
+BreachDefenseIntro::~BreachDefenseIntro() {
+    game = nullptr;
+}
+
+void BreachDefenseIntro::onStateMounted(Device* PDN) {
+    transitionToWinState = false;
+
+    LOG_I(TAG, "Breach Defense intro");
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("BREACH DEFENSE", 10, 20)
+        ->drawText("Hold the line.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start intro timer — stub auto-wins after this
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void BreachDefenseIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToWinState = true;
+    }
+}
+
+void BreachDefenseIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToWinState = false;
+}
+
+bool BreachDefenseIntro::transitionToWin() {
+    return transitionToWinState;
+}

--- a/src/game/breach-defense/breach-defense-lose.cpp
+++ b/src/game/breach-defense/breach-defense-lose.cpp
@@ -1,0 +1,59 @@
+#include "game/breach-defense/breach-defense-states.hpp"
+#include "game/breach-defense/breach-defense.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "BreachDefenseLose";
+
+BreachDefenseLose::BreachDefenseLose(BreachDefense* game) : State(BREACH_LOSE) {
+    this->game = game;
+}
+
+BreachDefenseLose::~BreachDefenseLose() {
+    game = nullptr;
+}
+
+void BreachDefenseLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = 0;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    LOG_I(TAG, "BREACH OPEN");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("BREACH OPEN", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(255);
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void BreachDefenseLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void BreachDefenseLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool BreachDefenseLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool BreachDefenseLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/breach-defense/breach-defense-win.cpp
+++ b/src/game/breach-defense/breach-defense-win.cpp
@@ -1,0 +1,62 @@
+#include "game/breach-defense/breach-defense-states.hpp"
+#include "game/breach-defense/breach-defense.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "BreachDefenseWin";
+
+BreachDefenseWin::BreachDefenseWin(BreachDefense* game) : State(BREACH_WIN) {
+    this->game = game;
+}
+
+BreachDefenseWin::~BreachDefenseWin() {
+    game = nullptr;
+}
+
+void BreachDefenseWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    // Stub: always easy-mode win (hardMode = false)
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = 100;
+    winOutcome.hardMode = false;
+    game->setOutcome(winOutcome);
+
+    LOG_I(TAG, "BREACH BLOCKED");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("BREACH BLOCKED", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void BreachDefenseWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void BreachDefenseWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool BreachDefenseWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool BreachDefenseWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/breach-defense/breach-defense.cpp
+++ b/src/game/breach-defense/breach-defense.cpp
@@ -1,0 +1,34 @@
+#include "game/breach-defense/breach-defense.hpp"
+#include "game/breach-defense/breach-defense-states.hpp"
+
+void BreachDefense::populateStateMap() {
+    BreachDefenseIntro* intro = new BreachDefenseIntro(this);
+    BreachDefenseWin* win = new BreachDefenseWin(this);
+    BreachDefenseLose* lose = new BreachDefenseLose(this);
+
+    // Stub: intro auto-transitions to win
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&BreachDefenseIntro::transitionToWin, intro),
+            win));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&BreachDefenseWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&BreachDefenseLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void BreachDefense::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}

--- a/src/game/cipher-path/cipher-path-intro.cpp
+++ b/src/game/cipher-path/cipher-path-intro.cpp
@@ -1,0 +1,48 @@
+#include "game/cipher-path/cipher-path-states.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "CipherPathIntro";
+
+CipherPathIntro::CipherPathIntro(CipherPath* game) : State(CIPHER_INTRO) {
+    this->game = game;
+}
+
+CipherPathIntro::~CipherPathIntro() {
+    game = nullptr;
+}
+
+void CipherPathIntro::onStateMounted(Device* PDN) {
+    transitionToWinState = false;
+
+    LOG_I(TAG, "Cipher Path intro");
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("CIPHER PATH", 10, 20)
+        ->drawText("Find the way.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start intro timer — stub auto-wins after this
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void CipherPathIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToWinState = true;
+    }
+}
+
+void CipherPathIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToWinState = false;
+}
+
+bool CipherPathIntro::transitionToWin() {
+    return transitionToWinState;
+}

--- a/src/game/cipher-path/cipher-path-lose.cpp
+++ b/src/game/cipher-path/cipher-path-lose.cpp
@@ -1,0 +1,59 @@
+#include "game/cipher-path/cipher-path-states.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "CipherPathLose";
+
+CipherPathLose::CipherPathLose(CipherPath* game) : State(CIPHER_LOSE) {
+    this->game = game;
+}
+
+CipherPathLose::~CipherPathLose() {
+    game = nullptr;
+}
+
+void CipherPathLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = 0;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    LOG_I(TAG, "PATH LOST");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("PATH LOST", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(255);
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void CipherPathLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void CipherPathLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool CipherPathLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool CipherPathLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/cipher-path/cipher-path-win.cpp
+++ b/src/game/cipher-path/cipher-path-win.cpp
@@ -1,0 +1,62 @@
+#include "game/cipher-path/cipher-path-states.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "CipherPathWin";
+
+CipherPathWin::CipherPathWin(CipherPath* game) : State(CIPHER_WIN) {
+    this->game = game;
+}
+
+CipherPathWin::~CipherPathWin() {
+    game = nullptr;
+}
+
+void CipherPathWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    // Stub: always easy-mode win (hardMode = false)
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = 100;
+    winOutcome.hardMode = false;
+    game->setOutcome(winOutcome);
+
+    LOG_I(TAG, "PATH DECODED");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("PATH DECODED", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void CipherPathWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void CipherPathWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool CipherPathWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool CipherPathWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/cipher-path/cipher-path.cpp
+++ b/src/game/cipher-path/cipher-path.cpp
@@ -1,0 +1,34 @@
+#include "game/cipher-path/cipher-path.hpp"
+#include "game/cipher-path/cipher-path-states.hpp"
+
+void CipherPath::populateStateMap() {
+    CipherPathIntro* intro = new CipherPathIntro(this);
+    CipherPathWin* win = new CipherPathWin(this);
+    CipherPathLose* lose = new CipherPathLose(this);
+
+    // Stub: intro auto-transitions to win
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&CipherPathIntro::transitionToWin, intro),
+            win));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&CipherPathWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&CipherPathLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void CipherPath::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}

--- a/src/game/exploit-sequencer/exploit-sequencer-intro.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer-intro.cpp
@@ -1,0 +1,48 @@
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "ExploitSeqIntro";
+
+ExploitSequencerIntro::ExploitSequencerIntro(ExploitSequencer* game) : State(EXPLOIT_INTRO) {
+    this->game = game;
+}
+
+ExploitSequencerIntro::~ExploitSequencerIntro() {
+    game = nullptr;
+}
+
+void ExploitSequencerIntro::onStateMounted(Device* PDN) {
+    transitionToWinState = false;
+
+    LOG_I(TAG, "Exploit Sequencer intro");
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("EXPLOIT SEQUENCER", 10, 20)
+        ->drawText("Chain the ops.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start intro timer — stub auto-wins after this
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void ExploitSequencerIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToWinState = true;
+    }
+}
+
+void ExploitSequencerIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToWinState = false;
+}
+
+bool ExploitSequencerIntro::transitionToWin() {
+    return transitionToWinState;
+}

--- a/src/game/exploit-sequencer/exploit-sequencer-lose.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer-lose.cpp
@@ -1,0 +1,59 @@
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "ExploitSeqLose";
+
+ExploitSequencerLose::ExploitSequencerLose(ExploitSequencer* game) : State(EXPLOIT_LOSE) {
+    this->game = game;
+}
+
+ExploitSequencerLose::~ExploitSequencerLose() {
+    game = nullptr;
+}
+
+void ExploitSequencerLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = 0;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    LOG_I(TAG, "EXPLOIT FAILED");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("EXPLOIT FAILED", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(255);
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void ExploitSequencerLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void ExploitSequencerLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool ExploitSequencerLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool ExploitSequencerLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/exploit-sequencer/exploit-sequencer-win.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer-win.cpp
@@ -1,0 +1,62 @@
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "ExploitSeqWin";
+
+ExploitSequencerWin::ExploitSequencerWin(ExploitSequencer* game) : State(EXPLOIT_WIN) {
+    this->game = game;
+}
+
+ExploitSequencerWin::~ExploitSequencerWin() {
+    game = nullptr;
+}
+
+void ExploitSequencerWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    // Stub: always easy-mode win (hardMode = false)
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = 100;
+    winOutcome.hardMode = false;
+    game->setOutcome(winOutcome);
+
+    LOG_I(TAG, "EXPLOIT DONE");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("EXPLOIT DONE", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void ExploitSequencerWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void ExploitSequencerWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool ExploitSequencerWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool ExploitSequencerWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/exploit-sequencer/exploit-sequencer.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer.cpp
@@ -1,0 +1,34 @@
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+
+void ExploitSequencer::populateStateMap() {
+    ExploitSequencerIntro* intro = new ExploitSequencerIntro(this);
+    ExploitSequencerWin* win = new ExploitSequencerWin(this);
+    ExploitSequencerLose* lose = new ExploitSequencerLose(this);
+
+    // Stub: intro auto-transitions to win
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&ExploitSequencerIntro::transitionToWin, intro),
+            win));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&ExploitSequencerWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&ExploitSequencerLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void ExploitSequencer::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}

--- a/src/game/ghost-runner/ghost-runner-intro.cpp
+++ b/src/game/ghost-runner/ghost-runner-intro.cpp
@@ -1,0 +1,48 @@
+#include "game/ghost-runner/ghost-runner-states.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "GhostRunnerIntro";
+
+GhostRunnerIntro::GhostRunnerIntro(GhostRunner* game) : State(GHOST_INTRO) {
+    this->game = game;
+}
+
+GhostRunnerIntro::~GhostRunnerIntro() {
+    game = nullptr;
+}
+
+void GhostRunnerIntro::onStateMounted(Device* PDN) {
+    transitionToWinState = false;
+
+    LOG_I(TAG, "Ghost Runner intro");
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("GHOST RUNNER", 10, 20)
+        ->drawText("Phase through.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start intro timer — stub auto-wins after this
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void GhostRunnerIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToWinState = true;
+    }
+}
+
+void GhostRunnerIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToWinState = false;
+}
+
+bool GhostRunnerIntro::transitionToWin() {
+    return transitionToWinState;
+}

--- a/src/game/ghost-runner/ghost-runner-lose.cpp
+++ b/src/game/ghost-runner/ghost-runner-lose.cpp
@@ -1,0 +1,59 @@
+#include "game/ghost-runner/ghost-runner-states.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "GhostRunnerLose";
+
+GhostRunnerLose::GhostRunnerLose(GhostRunner* game) : State(GHOST_LOSE) {
+    this->game = game;
+}
+
+GhostRunnerLose::~GhostRunnerLose() {
+    game = nullptr;
+}
+
+void GhostRunnerLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = 0;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    LOG_I(TAG, "GHOST CAUGHT");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("GHOST CAUGHT", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(255);
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void GhostRunnerLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void GhostRunnerLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool GhostRunnerLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool GhostRunnerLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/ghost-runner/ghost-runner-win.cpp
+++ b/src/game/ghost-runner/ghost-runner-win.cpp
@@ -1,0 +1,62 @@
+#include "game/ghost-runner/ghost-runner-states.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "GhostRunnerWin";
+
+GhostRunnerWin::GhostRunnerWin(GhostRunner* game) : State(GHOST_WIN) {
+    this->game = game;
+}
+
+GhostRunnerWin::~GhostRunnerWin() {
+    game = nullptr;
+}
+
+void GhostRunnerWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    // Stub: always easy-mode win (hardMode = false)
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = 100;
+    winOutcome.hardMode = false;
+    game->setOutcome(winOutcome);
+
+    LOG_I(TAG, "RUN COMPLETE");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("RUN COMPLETE", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void GhostRunnerWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void GhostRunnerWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool GhostRunnerWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool GhostRunnerWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/ghost-runner/ghost-runner.cpp
+++ b/src/game/ghost-runner/ghost-runner.cpp
@@ -1,0 +1,34 @@
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "game/ghost-runner/ghost-runner-states.hpp"
+
+void GhostRunner::populateStateMap() {
+    GhostRunnerIntro* intro = new GhostRunnerIntro(this);
+    GhostRunnerWin* win = new GhostRunnerWin(this);
+    GhostRunnerLose* lose = new GhostRunnerLose(this);
+
+    // Stub: intro auto-transitions to win
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&GhostRunnerIntro::transitionToWin, intro),
+            win));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&GhostRunnerWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&GhostRunnerLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void GhostRunner::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}

--- a/src/game/quickdraw-states/fdn-detected-state.cpp
+++ b/src/game/quickdraw-states/fdn-detected-state.cpp
@@ -4,6 +4,11 @@
 #include "game/signal-echo/signal-echo-resources.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "game/breach-defense/breach-defense.hpp"
 #include "device/drivers/logger.hpp"
 #include "wireless/mac-functions.hpp"
 #include "device/device-constants.hpp"
@@ -124,6 +129,41 @@ void FdnDetected::onStateLoop(Device* PDN) {
                 FirewallDecryptConfig config = FIREWALL_DECRYPT_EASY;
                 config.managedMode = true;
                 fw->getConfig() = config;
+            }
+        } else if (pendingGameType == GameType::GHOST_RUNNER) {
+            auto* gr = static_cast<GhostRunner*>(game);
+            if (gr) {
+                GhostRunnerConfig config = GHOST_RUNNER_EASY;
+                config.managedMode = true;
+                gr->getConfig() = config;
+            }
+        } else if (pendingGameType == GameType::SPIKE_VECTOR) {
+            auto* sv = static_cast<SpikeVector*>(game);
+            if (sv) {
+                SpikeVectorConfig config = SPIKE_VECTOR_EASY;
+                config.managedMode = true;
+                sv->getConfig() = config;
+            }
+        } else if (pendingGameType == GameType::CIPHER_PATH) {
+            auto* cp = static_cast<CipherPath*>(game);
+            if (cp) {
+                CipherPathConfig config = CIPHER_PATH_EASY;
+                config.managedMode = true;
+                cp->getConfig() = config;
+            }
+        } else if (pendingGameType == GameType::EXPLOIT_SEQUENCER) {
+            auto* es = static_cast<ExploitSequencer*>(game);
+            if (es) {
+                ExploitSequencerConfig config = EXPLOIT_SEQUENCER_EASY;
+                config.managedMode = true;
+                es->getConfig() = config;
+            }
+        } else if (pendingGameType == GameType::BREACH_DEFENSE) {
+            auto* bd = static_cast<BreachDefense*>(game);
+            if (bd) {
+                BreachDefenseConfig config = BREACH_DEFENSE_EASY;
+                config.managedMode = true;
+                bd->getConfig() = config;
             }
         }
 

--- a/src/game/quickdraw-states/fdn-reencounter-state.cpp
+++ b/src/game/quickdraw-states/fdn-reencounter-state.cpp
@@ -4,6 +4,11 @@
 #include "game/signal-echo/signal-echo-resources.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "game/breach-defense/breach-defense.hpp"
 #include "device/drivers/logger.hpp"
 #include "device/device-types.hpp"
 #include <cstdint>
@@ -194,6 +199,41 @@ void FdnReencounter::launchGame(Device* PDN) {
             FirewallDecryptConfig config = hardMode ? FIREWALL_DECRYPT_HARD : FIREWALL_DECRYPT_EASY;
             config.managedMode = true;
             fw->getConfig() = config;
+        }
+    } else if (pendingGameType == GameType::GHOST_RUNNER) {
+        auto* gr = static_cast<GhostRunner*>(game);
+        if (gr) {
+            GhostRunnerConfig config = hardMode ? GHOST_RUNNER_HARD : GHOST_RUNNER_EASY;
+            config.managedMode = true;
+            gr->getConfig() = config;
+        }
+    } else if (pendingGameType == GameType::SPIKE_VECTOR) {
+        auto* sv = static_cast<SpikeVector*>(game);
+        if (sv) {
+            SpikeVectorConfig config = hardMode ? SPIKE_VECTOR_HARD : SPIKE_VECTOR_EASY;
+            config.managedMode = true;
+            sv->getConfig() = config;
+        }
+    } else if (pendingGameType == GameType::CIPHER_PATH) {
+        auto* cp = static_cast<CipherPath*>(game);
+        if (cp) {
+            CipherPathConfig config = hardMode ? CIPHER_PATH_HARD : CIPHER_PATH_EASY;
+            config.managedMode = true;
+            cp->getConfig() = config;
+        }
+    } else if (pendingGameType == GameType::EXPLOIT_SEQUENCER) {
+        auto* es = static_cast<ExploitSequencer*>(game);
+        if (es) {
+            ExploitSequencerConfig config = hardMode ? EXPLOIT_SEQUENCER_HARD : EXPLOIT_SEQUENCER_EASY;
+            config.managedMode = true;
+            es->getConfig() = config;
+        }
+    } else if (pendingGameType == GameType::BREACH_DEFENSE) {
+        auto* bd = static_cast<BreachDefense*>(game);
+        if (bd) {
+            BreachDefenseConfig config = hardMode ? BREACH_DEFENSE_HARD : BREACH_DEFENSE_EASY;
+            config.managedMode = true;
+            bd->getConfig() = config;
         }
     }
 

--- a/src/game/spike-vector/spike-vector-intro.cpp
+++ b/src/game/spike-vector/spike-vector-intro.cpp
@@ -1,0 +1,48 @@
+#include "game/spike-vector/spike-vector-states.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "SpikeVectorIntro";
+
+SpikeVectorIntro::SpikeVectorIntro(SpikeVector* game) : State(SPIKE_INTRO) {
+    this->game = game;
+}
+
+SpikeVectorIntro::~SpikeVectorIntro() {
+    game = nullptr;
+}
+
+void SpikeVectorIntro::onStateMounted(Device* PDN) {
+    transitionToWinState = false;
+
+    LOG_I(TAG, "Spike Vector intro");
+
+    // Reset session for a fresh game
+    game->getSession().reset();
+    game->resetGame();
+
+    // Display title screen
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SPIKE VECTOR", 10, 20)
+        ->drawText("Dodge the grid.", 10, 45);
+    PDN->getDisplay()->render();
+
+    // Start intro timer — stub auto-wins after this
+    introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void SpikeVectorIntro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToWinState = true;
+    }
+}
+
+void SpikeVectorIntro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToWinState = false;
+}
+
+bool SpikeVectorIntro::transitionToWin() {
+    return transitionToWinState;
+}

--- a/src/game/spike-vector/spike-vector-lose.cpp
+++ b/src/game/spike-vector/spike-vector-lose.cpp
@@ -1,0 +1,59 @@
+#include "game/spike-vector/spike-vector-states.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "SpikeVectorLose";
+
+SpikeVectorLose::SpikeVectorLose(SpikeVector* game) : State(SPIKE_LOSE) {
+    this->game = game;
+}
+
+SpikeVectorLose::~SpikeVectorLose() {
+    game = nullptr;
+}
+
+void SpikeVectorLose::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    MiniGameOutcome loseOutcome;
+    loseOutcome.result = MiniGameResult::LOST;
+    loseOutcome.score = 0;
+    loseOutcome.hardMode = false;
+    game->setOutcome(loseOutcome);
+
+    LOG_I(TAG, "SPIKE IMPACT");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("SPIKE IMPACT", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(255);
+
+    loseTimer.setTimer(LOSE_DISPLAY_MS);
+}
+
+void SpikeVectorLose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void SpikeVectorLose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool SpikeVectorLose::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool SpikeVectorLose::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/spike-vector/spike-vector-win.cpp
+++ b/src/game/spike-vector/spike-vector-win.cpp
@@ -1,0 +1,62 @@
+#include "game/spike-vector/spike-vector-states.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "device/drivers/logger.hpp"
+
+static const char* TAG = "SpikeVectorWin";
+
+SpikeVectorWin::SpikeVectorWin(SpikeVector* game) : State(SPIKE_WIN) {
+    this->game = game;
+}
+
+SpikeVectorWin::~SpikeVectorWin() {
+    game = nullptr;
+}
+
+void SpikeVectorWin::onStateMounted(Device* PDN) {
+    transitionToIntroState = false;
+
+    // Stub: always easy-mode win (hardMode = false)
+    MiniGameOutcome winOutcome;
+    winOutcome.result = MiniGameResult::WON;
+    winOutcome.score = 100;
+    winOutcome.hardMode = false;
+    game->setOutcome(winOutcome);
+
+    LOG_I(TAG, "VECTOR CLEAR");
+
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+        ->drawText("VECTOR CLEAR", 10, 30);
+    PDN->getDisplay()->render();
+
+    PDN->getHaptics()->setIntensity(200);
+
+    winTimer.setTimer(WIN_DISPLAY_MS);
+}
+
+void SpikeVectorWin::onStateLoop(Device* PDN) {
+    if (winTimer.expired()) {
+        PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            // In standalone mode, restart the game
+            transitionToIntroState = true;
+        } else {
+            // In managed mode, return to the previous app (e.g. Quickdraw)
+            PDN->returnToPreviousApp();
+        }
+    }
+}
+
+void SpikeVectorWin::onStateDismounted(Device* PDN) {
+    winTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
+
+bool SpikeVectorWin::transitionToIntro() {
+    return transitionToIntroState;
+}
+
+bool SpikeVectorWin::isTerminalState() {
+    return game->getConfig().managedMode;
+}

--- a/src/game/spike-vector/spike-vector.cpp
+++ b/src/game/spike-vector/spike-vector.cpp
@@ -1,0 +1,34 @@
+#include "game/spike-vector/spike-vector.hpp"
+#include "game/spike-vector/spike-vector-states.hpp"
+
+void SpikeVector::populateStateMap() {
+    SpikeVectorIntro* intro = new SpikeVectorIntro(this);
+    SpikeVectorWin* win = new SpikeVectorWin(this);
+    SpikeVectorLose* lose = new SpikeVectorLose(this);
+
+    // Stub: intro auto-transitions to win
+    intro->addTransition(
+        new StateTransition(
+            std::bind(&SpikeVectorIntro::transitionToWin, intro),
+            win));
+
+    // Standalone mode: win/lose loop back to intro for replay
+    win->addTransition(
+        new StateTransition(
+            std::bind(&SpikeVectorWin::transitionToIntro, win),
+            intro));
+
+    lose->addTransition(
+        new StateTransition(
+            std::bind(&SpikeVectorLose::transitionToIntro, lose),
+            intro));
+
+    stateMap.push_back(intro);
+    stateMap.push_back(win);
+    stateMap.push_back(lose);
+}
+
+void SpikeVector::resetGame() {
+    MiniGame::resetGame();
+    session.reset();
+}

--- a/test/test_cli/breach-defense-tests.hpp
+++ b/test/test_cli/breach-defense-tests.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/breach-defense/breach-defense.hpp"
+#include "game/breach-defense/breach-defense-states.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+#include <cstdint>
+
+using namespace cli;
+
+// ============================================
+// BREACH DEFENSE STUB TEST SUITE
+// ============================================
+
+class BreachDefenseStubTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            player_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    BreachDefense* getBreachDefense() {
+        return static_cast<BreachDefense*>(
+            player_.pdn->getApp(StateId(BREACH_DEFENSE_APP_ID)));
+    }
+
+    DeviceInstance player_;
+};
+
+// ============================================
+// STUB LIFECYCLE TESTS
+// ============================================
+
+/*
+ * Test: Game starts in Intro state when launched standalone.
+ * Creates a standalone game device and verifies the initial state.
+ */
+void breachDefenseStubIntroState(BreachDefenseStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "breach-defense");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), BREACH_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Intro auto-transitions to Win after 2 seconds (stub behavior).
+ * The stub has no real gameplay — intro -> win is the entire flow.
+ */
+void breachDefenseStubAutoWin(BreachDefenseStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "breach-defense");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), BREACH_INTRO);
+
+    // Advance past 2s intro timer
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), BREACH_WIN);
+
+    // Verify outcome was set
+    auto* bd = static_cast<BreachDefense*>(device.game);
+    ASSERT_EQ(bd->getOutcome().result, MiniGameResult::WON);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: In managed mode, Win state calls returnToPreviousApp.
+ * Launches Breach Defense via FDN handshake and plays through to win.
+ * After win timer expires, should return to Quickdraw (FdnComplete).
+ */
+void breachDefenseStubManagedModeReturns(BreachDefenseStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN handshake for Breach Defense (GameType 6, KonamiButton A=5)
+    suite->player_.serialOutDriver->injectInput("*fdn:6:5\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Complete handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Should be in Breach Defense Intro now
+    auto* bd = suite->getBreachDefense();
+    ASSERT_NE(bd, nullptr);
+    ASSERT_TRUE(bd->getConfig().managedMode);
+
+    // Advance past intro timer (2s)
+    suite->tickWithTime(25, 100);
+
+    // Should be in Breach Defense Win
+    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+
+    // Advance past win timer (3s)
+    suite->tickWithTime(35, 100);
+
+    // Should return to Quickdraw's FdnComplete state
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: In standalone mode, Win state loops back to Intro.
+ * The default standalone config has managedMode = false.
+ */
+void breachDefenseStubStandaloneLoops(BreachDefenseStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "breach-defense");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    // Advance past intro (2s) -> win state
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), BREACH_WIN);
+
+    // Advance past win timer (3s) -> should loop to intro
+    for (int i = 0; i < 35; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), BREACH_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Full FDN flow — detected -> handshake -> game launch -> win -> FdnComplete.
+ * This exercises the routing in fdn-detected-state.cpp and the managed mode return.
+ */
+void breachDefenseStubFdnLaunch(BreachDefenseStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject FDN broadcast
+    suite->player_.serialOutDriver->injectInput("*fdn:6:5\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Now in Breach Defense
+    auto* bd = suite->getBreachDefense();
+    ASSERT_NE(bd, nullptr);
+    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_INTRO);
+
+    // Play through stub (intro 2s + win 3s)
+    suite->tickWithTime(25, 100);  // Past intro
+    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getOutcome().result, MiniGameResult::WON);
+
+    suite->tickWithTime(35, 100);  // Past win timer
+
+    // Back in Quickdraw
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: App ID is correctly registered in getAppIdForGame().
+ */
+void breachDefenseStubAppIdRegistered(BreachDefenseStubTestSuite* suite) {
+    ASSERT_EQ(getAppIdForGame(GameType::BREACH_DEFENSE), BREACH_DEFENSE_APP_ID);
+    ASSERT_EQ(BREACH_DEFENSE_APP_ID, 8);
+}
+
+/*
+ * Test: State names resolve correctly for CLI display.
+ */
+void breachDefenseStubStateNames(BreachDefenseStubTestSuite* suite) {
+    ASSERT_STREQ(getBreachDefenseStateName(BREACH_INTRO), "BreachDefenseIntro");
+    ASSERT_STREQ(getBreachDefenseStateName(BREACH_WIN), "BreachDefenseWin");
+    ASSERT_STREQ(getBreachDefenseStateName(BREACH_LOSE), "BreachDefenseLose");
+
+    // Verify getStateName routes correctly
+    ASSERT_STREQ(getStateName(BREACH_INTRO), "BreachDefenseIntro");
+    ASSERT_STREQ(getStateName(BREACH_WIN), "BreachDefenseWin");
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/cipher-path-tests.hpp
+++ b/test/test_cli/cipher-path-tests.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/cipher-path/cipher-path.hpp"
+#include "game/cipher-path/cipher-path-states.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+#include <cstdint>
+
+using namespace cli;
+
+// ============================================
+// CIPHER PATH STUB TEST SUITE
+// ============================================
+
+class CipherPathStubTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            player_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    CipherPath* getCipherPath() {
+        return static_cast<CipherPath*>(
+            player_.pdn->getApp(StateId(CIPHER_PATH_APP_ID)));
+    }
+
+    DeviceInstance player_;
+};
+
+// ============================================
+// STUB LIFECYCLE TESTS
+// ============================================
+
+/*
+ * Test: Game starts in Intro state when launched standalone.
+ * Creates a standalone game device and verifies the initial state.
+ */
+void cipherPathStubIntroState(CipherPathStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "cipher-path");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), CIPHER_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Intro auto-transitions to Win after 2 seconds (stub behavior).
+ * The stub has no real gameplay — intro -> win is the entire flow.
+ */
+void cipherPathStubAutoWin(CipherPathStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "cipher-path");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), CIPHER_INTRO);
+
+    // Advance past 2s intro timer
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), CIPHER_WIN);
+
+    // Verify outcome was set
+    auto* cp = static_cast<CipherPath*>(device.game);
+    ASSERT_EQ(cp->getOutcome().result, MiniGameResult::WON);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: In managed mode, Win state calls returnToPreviousApp.
+ * Launches Cipher Path via FDN handshake and plays through to win.
+ * After win timer expires, should return to Quickdraw (FdnComplete).
+ */
+void cipherPathStubManagedModeReturns(CipherPathStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN handshake for Cipher Path (GameType 4, KonamiButton RIGHT=3)
+    suite->player_.serialOutDriver->injectInput("*fdn:4:3\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Complete handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Should be in Cipher Path Intro now
+    auto* cp = suite->getCipherPath();
+    ASSERT_NE(cp, nullptr);
+    ASSERT_TRUE(cp->getConfig().managedMode);
+
+    // Advance past intro timer (2s)
+    suite->tickWithTime(25, 100);
+
+    // Should be in Cipher Path Win
+    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+
+    // Advance past win timer (3s)
+    suite->tickWithTime(35, 100);
+
+    // Should return to Quickdraw's FdnComplete state
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: In standalone mode, Win state loops back to Intro.
+ * The default standalone config has managedMode = false.
+ */
+void cipherPathStubStandaloneLoops(CipherPathStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "cipher-path");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    // Advance past intro (2s) -> win state
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), CIPHER_WIN);
+
+    // Advance past win timer (3s) -> should loop to intro
+    for (int i = 0; i < 35; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), CIPHER_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Full FDN flow — detected -> handshake -> game launch -> win -> FdnComplete.
+ * This exercises the routing in fdn-detected-state.cpp and the managed mode return.
+ */
+void cipherPathStubFdnLaunch(CipherPathStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject FDN broadcast
+    suite->player_.serialOutDriver->injectInput("*fdn:4:3\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Now in Cipher Path
+    auto* cp = suite->getCipherPath();
+    ASSERT_NE(cp, nullptr);
+    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_INTRO);
+
+    // Play through stub (intro 2s + win 3s)
+    suite->tickWithTime(25, 100);  // Past intro
+    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getOutcome().result, MiniGameResult::WON);
+
+    suite->tickWithTime(35, 100);  // Past win timer
+
+    // Back in Quickdraw
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: App ID is correctly registered in getAppIdForGame().
+ */
+void cipherPathStubAppIdRegistered(CipherPathStubTestSuite* suite) {
+    ASSERT_EQ(getAppIdForGame(GameType::CIPHER_PATH), CIPHER_PATH_APP_ID);
+    ASSERT_EQ(CIPHER_PATH_APP_ID, 6);
+}
+
+/*
+ * Test: State names resolve correctly for CLI display.
+ */
+void cipherPathStubStateNames(CipherPathStubTestSuite* suite) {
+    ASSERT_STREQ(getCipherPathStateName(CIPHER_INTRO), "CipherPathIntro");
+    ASSERT_STREQ(getCipherPathStateName(CIPHER_WIN), "CipherPathWin");
+    ASSERT_STREQ(getCipherPathStateName(CIPHER_LOSE), "CipherPathLose");
+
+    // Verify getStateName routes correctly
+    ASSERT_STREQ(getStateName(CIPHER_INTRO), "CipherPathIntro");
+    ASSERT_STREQ(getStateName(CIPHER_WIN), "CipherPathWin");
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/cli-tests.cpp
+++ b/test/test_cli/cli-tests.cpp
@@ -21,6 +21,11 @@
 #include "firewall-decrypt-tests.hpp"
 #include "progression-e2e-tests.hpp"
 #include "negative-flow-tests.hpp"
+#include "ghost-runner-tests.hpp"
+#include "spike-vector-tests.hpp"
+#include "cipher-path-tests.hpp"
+#include "exploit-sequencer-tests.hpp"
+#include "breach-defense-tests.hpp"
 
 // ============================================
 // SERIAL CABLE BROKER TESTS
@@ -1224,6 +1229,166 @@ TEST_F(BountyFlowTestSuite, BountyFdnHardWinColorPrompt) {
 
 TEST_F(BountyFlowTestSuite, BountyReencounterPrompt) {
     bountyReencounterPrompt(this);
+}
+
+// ============================================
+// GHOST RUNNER STUB TESTS
+// ============================================
+
+TEST_F(GhostRunnerStubTestSuite, StubIntroState) {
+    ghostRunnerStubIntroState(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubAutoWin) {
+    ghostRunnerStubAutoWin(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubManagedModeReturns) {
+    ghostRunnerStubManagedModeReturns(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubStandaloneLoops) {
+    ghostRunnerStubStandaloneLoops(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubFdnLaunch) {
+    ghostRunnerStubFdnLaunch(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubAppIdRegistered) {
+    ghostRunnerStubAppIdRegistered(this);
+}
+
+TEST_F(GhostRunnerStubTestSuite, StubStateNames) {
+    ghostRunnerStubStateNames(this);
+}
+
+// ============================================
+// SPIKE VECTOR STUB TESTS
+// ============================================
+
+TEST_F(SpikeVectorStubTestSuite, StubIntroState) {
+    spikeVectorStubIntroState(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubAutoWin) {
+    spikeVectorStubAutoWin(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubManagedModeReturns) {
+    spikeVectorStubManagedModeReturns(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubStandaloneLoops) {
+    spikeVectorStubStandaloneLoops(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubFdnLaunch) {
+    spikeVectorStubFdnLaunch(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubAppIdRegistered) {
+    spikeVectorStubAppIdRegistered(this);
+}
+
+TEST_F(SpikeVectorStubTestSuite, StubStateNames) {
+    spikeVectorStubStateNames(this);
+}
+
+// ============================================
+// CIPHER PATH STUB TESTS
+// ============================================
+
+TEST_F(CipherPathStubTestSuite, StubIntroState) {
+    cipherPathStubIntroState(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubAutoWin) {
+    cipherPathStubAutoWin(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubManagedModeReturns) {
+    cipherPathStubManagedModeReturns(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubStandaloneLoops) {
+    cipherPathStubStandaloneLoops(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubFdnLaunch) {
+    cipherPathStubFdnLaunch(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubAppIdRegistered) {
+    cipherPathStubAppIdRegistered(this);
+}
+
+TEST_F(CipherPathStubTestSuite, StubStateNames) {
+    cipherPathStubStateNames(this);
+}
+
+// ============================================
+// EXPLOIT SEQUENCER STUB TESTS
+// ============================================
+
+TEST_F(ExploitSequencerStubTestSuite, StubIntroState) {
+    exploitSequencerStubIntroState(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubAutoWin) {
+    exploitSequencerStubAutoWin(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubManagedModeReturns) {
+    exploitSequencerStubManagedModeReturns(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubStandaloneLoops) {
+    exploitSequencerStubStandaloneLoops(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubFdnLaunch) {
+    exploitSequencerStubFdnLaunch(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubAppIdRegistered) {
+    exploitSequencerStubAppIdRegistered(this);
+}
+
+TEST_F(ExploitSequencerStubTestSuite, StubStateNames) {
+    exploitSequencerStubStateNames(this);
+}
+
+// ============================================
+// BREACH DEFENSE STUB TESTS
+// ============================================
+
+TEST_F(BreachDefenseStubTestSuite, StubIntroState) {
+    breachDefenseStubIntroState(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubAutoWin) {
+    breachDefenseStubAutoWin(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubManagedModeReturns) {
+    breachDefenseStubManagedModeReturns(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubStandaloneLoops) {
+    breachDefenseStubStandaloneLoops(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubFdnLaunch) {
+    breachDefenseStubFdnLaunch(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubAppIdRegistered) {
+    breachDefenseStubAppIdRegistered(this);
+}
+
+TEST_F(BreachDefenseStubTestSuite, StubStateNames) {
+    breachDefenseStubStateNames(this);
 }
 
 // ============================================

--- a/test/test_cli/exploit-sequencer-tests.hpp
+++ b/test/test_cli/exploit-sequencer-tests.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/exploit-sequencer/exploit-sequencer.hpp"
+#include "game/exploit-sequencer/exploit-sequencer-states.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+#include <cstdint>
+
+using namespace cli;
+
+// ============================================
+// EXPLOIT SEQUENCER STUB TEST SUITE
+// ============================================
+
+class ExploitSequencerStubTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            player_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    ExploitSequencer* getExploitSequencer() {
+        return static_cast<ExploitSequencer*>(
+            player_.pdn->getApp(StateId(EXPLOIT_SEQUENCER_APP_ID)));
+    }
+
+    DeviceInstance player_;
+};
+
+// ============================================
+// STUB LIFECYCLE TESTS
+// ============================================
+
+/*
+ * Test: Game starts in Intro state when launched standalone.
+ * Creates a standalone game device and verifies the initial state.
+ */
+void exploitSequencerStubIntroState(ExploitSequencerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "exploit-sequencer");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), EXPLOIT_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Intro auto-transitions to Win after 2 seconds (stub behavior).
+ * The stub has no real gameplay — intro -> win is the entire flow.
+ */
+void exploitSequencerStubAutoWin(ExploitSequencerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "exploit-sequencer");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), EXPLOIT_INTRO);
+
+    // Advance past 2s intro timer
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), EXPLOIT_WIN);
+
+    // Verify outcome was set
+    auto* es = static_cast<ExploitSequencer*>(device.game);
+    ASSERT_EQ(es->getOutcome().result, MiniGameResult::WON);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: In managed mode, Win state calls returnToPreviousApp.
+ * Launches Exploit Sequencer via FDN handshake and plays through to win.
+ * After win timer expires, should return to Quickdraw (FdnComplete).
+ */
+void exploitSequencerStubManagedModeReturns(ExploitSequencerStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN handshake for Exploit Sequencer (GameType 5, KonamiButton B=4)
+    suite->player_.serialOutDriver->injectInput("*fdn:5:4\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Complete handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Should be in Exploit Sequencer Intro now
+    auto* es = suite->getExploitSequencer();
+    ASSERT_NE(es, nullptr);
+    ASSERT_TRUE(es->getConfig().managedMode);
+
+    // Advance past intro timer (2s)
+    suite->tickWithTime(25, 100);
+
+    // Should be in Exploit Sequencer Win
+    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+
+    // Advance past win timer (3s)
+    suite->tickWithTime(35, 100);
+
+    // Should return to Quickdraw's FdnComplete state
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: In standalone mode, Win state loops back to Intro.
+ * The default standalone config has managedMode = false.
+ */
+void exploitSequencerStubStandaloneLoops(ExploitSequencerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "exploit-sequencer");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    // Advance past intro (2s) -> win state
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), EXPLOIT_WIN);
+
+    // Advance past win timer (3s) -> should loop to intro
+    for (int i = 0; i < 35; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), EXPLOIT_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Full FDN flow — detected -> handshake -> game launch -> win -> FdnComplete.
+ * This exercises the routing in fdn-detected-state.cpp and the managed mode return.
+ */
+void exploitSequencerStubFdnLaunch(ExploitSequencerStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject FDN broadcast
+    suite->player_.serialOutDriver->injectInput("*fdn:5:4\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Now in Exploit Sequencer
+    auto* es = suite->getExploitSequencer();
+    ASSERT_NE(es, nullptr);
+    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_INTRO);
+
+    // Play through stub (intro 2s + win 3s)
+    suite->tickWithTime(25, 100);  // Past intro
+    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getOutcome().result, MiniGameResult::WON);
+
+    suite->tickWithTime(35, 100);  // Past win timer
+
+    // Back in Quickdraw
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: App ID is correctly registered in getAppIdForGame().
+ */
+void exploitSequencerStubAppIdRegistered(ExploitSequencerStubTestSuite* suite) {
+    ASSERT_EQ(getAppIdForGame(GameType::EXPLOIT_SEQUENCER), EXPLOIT_SEQUENCER_APP_ID);
+    ASSERT_EQ(EXPLOIT_SEQUENCER_APP_ID, 7);
+}
+
+/*
+ * Test: State names resolve correctly for CLI display.
+ */
+void exploitSequencerStubStateNames(ExploitSequencerStubTestSuite* suite) {
+    ASSERT_STREQ(getExploitSequencerStateName(EXPLOIT_INTRO), "ExploitSeqIntro");
+    ASSERT_STREQ(getExploitSequencerStateName(EXPLOIT_WIN), "ExploitSeqWin");
+    ASSERT_STREQ(getExploitSequencerStateName(EXPLOIT_LOSE), "ExploitSeqLose");
+
+    // Verify getStateName routes correctly
+    ASSERT_STREQ(getStateName(EXPLOIT_INTRO), "ExploitSeqIntro");
+    ASSERT_STREQ(getStateName(EXPLOIT_WIN), "ExploitSeqWin");
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/ghost-runner-tests.hpp
+++ b/test/test_cli/ghost-runner-tests.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/ghost-runner/ghost-runner.hpp"
+#include "game/ghost-runner/ghost-runner-states.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+#include <cstdint>
+
+using namespace cli;
+
+// ============================================
+// GHOST RUNNER STUB TEST SUITE
+// ============================================
+
+class GhostRunnerStubTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            player_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    GhostRunner* getGhostRunner() {
+        return static_cast<GhostRunner*>(
+            player_.pdn->getApp(StateId(GHOST_RUNNER_APP_ID)));
+    }
+
+    DeviceInstance player_;
+};
+
+// ============================================
+// STUB LIFECYCLE TESTS
+// ============================================
+
+/*
+ * Test: Game starts in Intro state when launched standalone.
+ * Creates a standalone game device and verifies the initial state.
+ */
+void ghostRunnerStubIntroState(GhostRunnerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "ghost-runner");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), GHOST_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Intro auto-transitions to Win after 2 seconds (stub behavior).
+ * The stub has no real gameplay — intro -> win is the entire flow.
+ */
+void ghostRunnerStubAutoWin(GhostRunnerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "ghost-runner");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), GHOST_INTRO);
+
+    // Advance past 2s intro timer
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), GHOST_WIN);
+
+    // Verify outcome was set
+    auto* gr = static_cast<GhostRunner*>(device.game);
+    ASSERT_EQ(gr->getOutcome().result, MiniGameResult::WON);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: In managed mode, Win state calls returnToPreviousApp.
+ * Launches Ghost Runner via FDN handshake and plays through to win.
+ * After win timer expires, should return to Quickdraw (FdnComplete).
+ */
+void ghostRunnerStubManagedModeReturns(GhostRunnerStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN handshake for Ghost Runner (GameType 1, KonamiButton UP=0)
+    suite->player_.serialOutDriver->injectInput("*fdn:1:0\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Complete handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Should be in Ghost Runner Intro now
+    auto* gr = suite->getGhostRunner();
+    ASSERT_NE(gr, nullptr);
+    ASSERT_TRUE(gr->getConfig().managedMode);
+
+    // Advance past intro timer (2s)
+    suite->tickWithTime(25, 100);
+
+    // Should be in Ghost Runner Win
+    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+
+    // Advance past win timer (3s)
+    suite->tickWithTime(35, 100);
+
+    // Should return to Quickdraw's FdnComplete state
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: In standalone mode, Win state loops back to Intro.
+ * The default standalone config has managedMode = false.
+ */
+void ghostRunnerStubStandaloneLoops(GhostRunnerStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "ghost-runner");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    // Advance past intro (2s) -> win state
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), GHOST_WIN);
+
+    // Advance past win timer (3s) -> should loop to intro
+    for (int i = 0; i < 35; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), GHOST_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Full FDN flow — detected -> handshake -> game launch -> win -> FdnComplete.
+ * This exercises the routing in fdn-detected-state.cpp and the managed mode return.
+ */
+void ghostRunnerStubFdnLaunch(GhostRunnerStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject FDN broadcast
+    suite->player_.serialOutDriver->injectInput("*fdn:1:0\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Now in Ghost Runner
+    auto* gr = suite->getGhostRunner();
+    ASSERT_NE(gr, nullptr);
+    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_INTRO);
+
+    // Play through stub (intro 2s + win 3s)
+    suite->tickWithTime(25, 100);  // Past intro
+    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getOutcome().result, MiniGameResult::WON);
+
+    suite->tickWithTime(35, 100);  // Past win timer
+
+    // Back in Quickdraw
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: App ID is correctly registered in getAppIdForGame().
+ */
+void ghostRunnerStubAppIdRegistered(GhostRunnerStubTestSuite* suite) {
+    ASSERT_EQ(getAppIdForGame(GameType::GHOST_RUNNER), GHOST_RUNNER_APP_ID);
+    ASSERT_EQ(GHOST_RUNNER_APP_ID, 4);
+}
+
+/*
+ * Test: State names resolve correctly for CLI display.
+ */
+void ghostRunnerStubStateNames(GhostRunnerStubTestSuite* suite) {
+    ASSERT_STREQ(getGhostRunnerStateName(GHOST_INTRO), "GhostRunnerIntro");
+    ASSERT_STREQ(getGhostRunnerStateName(GHOST_WIN), "GhostRunnerWin");
+    ASSERT_STREQ(getGhostRunnerStateName(GHOST_LOSE), "GhostRunnerLose");
+
+    // Verify getStateName routes correctly
+    ASSERT_STREQ(getStateName(GHOST_INTRO), "GhostRunnerIntro");
+    ASSERT_STREQ(getStateName(GHOST_WIN), "GhostRunnerWin");
+}
+
+#endif // NATIVE_BUILD

--- a/test/test_cli/progression-core-tests.hpp
+++ b/test/test_cli/progression-core-tests.hpp
@@ -452,7 +452,11 @@ void gameRoutingSignalEcho(GameRoutingTestSuite* /*suite*/) {
     ASSERT_EQ(getAppIdForGame(GameType::SIGNAL_ECHO), 2);
     ASSERT_EQ(getAppIdForGame(GameType::FIREWALL_DECRYPT), 3);
     ASSERT_EQ(getAppIdForGame(GameType::QUICKDRAW), -1);
-    ASSERT_EQ(getAppIdForGame(GameType::GHOST_RUNNER), -1);
+    ASSERT_EQ(getAppIdForGame(GameType::GHOST_RUNNER), 4);
+    ASSERT_EQ(getAppIdForGame(GameType::SPIKE_VECTOR), 5);
+    ASSERT_EQ(getAppIdForGame(GameType::CIPHER_PATH), 6);
+    ASSERT_EQ(getAppIdForGame(GameType::EXPLOIT_SEQUENCER), 7);
+    ASSERT_EQ(getAppIdForGame(GameType::BREACH_DEFENSE), 8);
 }
 
 // ============================================

--- a/test/test_cli/spike-vector-tests.hpp
+++ b/test/test_cli/spike-vector-tests.hpp
@@ -1,0 +1,229 @@
+#pragma once
+
+#ifdef NATIVE_BUILD
+
+#include <gtest/gtest.h>
+#include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "game/spike-vector/spike-vector.hpp"
+#include "game/spike-vector/spike-vector-states.hpp"
+#include "game/minigame.hpp"
+#include "device/device-types.hpp"
+#include "utils/simple-timer.hpp"
+#include <cstdint>
+
+using namespace cli;
+
+// ============================================
+// SPIKE VECTOR STUB TEST SUITE
+// ============================================
+
+class SpikeVectorStubTestSuite : public testing::Test {
+public:
+    void SetUp() override {
+        player_ = DeviceFactory::createDevice(0, true);
+        SimpleTimer::setPlatformClock(player_.clockDriver);
+    }
+
+    void TearDown() override {
+        SimpleTimer::setPlatformClock(nullptr);
+        DeviceFactory::destroyDevice(player_);
+    }
+
+    void tick(int n = 1) {
+        for (int i = 0; i < n; i++) {
+            player_.pdn->loop();
+        }
+    }
+
+    void tickWithTime(int n, int delayMs) {
+        for (int i = 0; i < n; i++) {
+            player_.clockDriver->advance(delayMs);
+            player_.pdn->loop();
+        }
+    }
+
+    void advanceToIdle() {
+        player_.game->skipToState(player_.pdn, 7);
+        player_.pdn->loop();
+    }
+
+    int getPlayerStateId() {
+        return player_.game->getCurrentState()->getStateId();
+    }
+
+    SpikeVector* getSpikeVector() {
+        return static_cast<SpikeVector*>(
+            player_.pdn->getApp(StateId(SPIKE_VECTOR_APP_ID)));
+    }
+
+    DeviceInstance player_;
+};
+
+// ============================================
+// STUB LIFECYCLE TESTS
+// ============================================
+
+/*
+ * Test: Game starts in Intro state when launched standalone.
+ * Creates a standalone game device and verifies the initial state.
+ */
+void spikeVectorStubIntroState(SpikeVectorStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "spike-vector");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    State* state = device.game->getCurrentState();
+    ASSERT_NE(state, nullptr);
+    ASSERT_EQ(state->getStateId(), SPIKE_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Intro auto-transitions to Win after 2 seconds (stub behavior).
+ * The stub has no real gameplay — intro -> win is the entire flow.
+ */
+void spikeVectorStubAutoWin(SpikeVectorStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "spike-vector");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), SPIKE_INTRO);
+
+    // Advance past 2s intro timer
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), SPIKE_WIN);
+
+    // Verify outcome was set
+    auto* sv = static_cast<SpikeVector*>(device.game);
+    ASSERT_EQ(sv->getOutcome().result, MiniGameResult::WON);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: In managed mode, Win state calls returnToPreviousApp.
+ * Launches Spike Vector via FDN handshake and plays through to win.
+ * After win timer expires, should return to Quickdraw (FdnComplete).
+ */
+void spikeVectorStubManagedModeReturns(SpikeVectorStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Trigger FDN handshake for Spike Vector (GameType 2, KonamiButton DOWN=1)
+    suite->player_.serialOutDriver->injectInput("*fdn:2:1\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Complete handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Should be in Spike Vector Intro now
+    auto* sv = suite->getSpikeVector();
+    ASSERT_NE(sv, nullptr);
+    ASSERT_TRUE(sv->getConfig().managedMode);
+
+    // Advance past intro timer (2s)
+    suite->tickWithTime(25, 100);
+
+    // Should be in Spike Vector Win
+    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+
+    // Advance past win timer (3s)
+    suite->tickWithTime(35, 100);
+
+    // Should return to Quickdraw's FdnComplete state
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: In standalone mode, Win state loops back to Intro.
+ * The default standalone config has managedMode = false.
+ */
+void spikeVectorStubStandaloneLoops(SpikeVectorStubTestSuite* suite) {
+    DeviceInstance device = DeviceFactory::createGameDevice(10, "spike-vector");
+    SimpleTimer::setPlatformClock(device.clockDriver);
+
+    // Advance past intro (2s) -> win state
+    for (int i = 0; i < 25; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), SPIKE_WIN);
+
+    // Advance past win timer (3s) -> should loop to intro
+    for (int i = 0; i < 35; i++) {
+        device.clockDriver->advance(100);
+        device.pdn->loop();
+    }
+    ASSERT_EQ(device.game->getCurrentState()->getStateId(), SPIKE_INTRO);
+
+    SimpleTimer::setPlatformClock(suite->player_.clockDriver);
+    DeviceFactory::destroyDevice(device);
+}
+
+/*
+ * Test: Full FDN flow — detected -> handshake -> game launch -> win -> FdnComplete.
+ * This exercises the routing in fdn-detected-state.cpp and the managed mode return.
+ */
+void spikeVectorStubFdnLaunch(SpikeVectorStubTestSuite* suite) {
+    suite->advanceToIdle();
+
+    // Inject FDN broadcast
+    suite->player_.serialOutDriver->injectInput("*fdn:2:1\r");
+    for (int i = 0; i < 3; i++) {
+        SerialCableBroker::getInstance().transferData();
+        suite->player_.pdn->loop();
+    }
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_DETECTED);
+
+    // Handshake
+    suite->player_.serialOutDriver->injectInput("*fack\r");
+    suite->tickWithTime(5, 100);
+
+    // Now in Spike Vector
+    auto* sv = suite->getSpikeVector();
+    ASSERT_NE(sv, nullptr);
+    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_INTRO);
+
+    // Play through stub (intro 2s + win 3s)
+    suite->tickWithTime(25, 100);  // Past intro
+    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getOutcome().result, MiniGameResult::WON);
+
+    suite->tickWithTime(35, 100);  // Past win timer
+
+    // Back in Quickdraw
+    ASSERT_EQ(suite->getPlayerStateId(), FDN_COMPLETE);
+}
+
+/*
+ * Test: App ID is correctly registered in getAppIdForGame().
+ */
+void spikeVectorStubAppIdRegistered(SpikeVectorStubTestSuite* suite) {
+    ASSERT_EQ(getAppIdForGame(GameType::SPIKE_VECTOR), SPIKE_VECTOR_APP_ID);
+    ASSERT_EQ(SPIKE_VECTOR_APP_ID, 5);
+}
+
+/*
+ * Test: State names resolve correctly for CLI display.
+ */
+void spikeVectorStubStateNames(SpikeVectorStubTestSuite* suite) {
+    ASSERT_STREQ(getSpikeVectorStateName(SPIKE_INTRO), "SpikeVectorIntro");
+    ASSERT_STREQ(getSpikeVectorStateName(SPIKE_WIN), "SpikeVectorWin");
+    ASSERT_STREQ(getSpikeVectorStateName(SPIKE_LOSE), "SpikeVectorLose");
+
+    // Verify getStateName routes correctly
+    ASSERT_STREQ(getStateName(SPIKE_INTRO), "SpikeVectorIntro");
+    ASSERT_STREQ(getStateName(SPIKE_WIN), "SpikeVectorWin");
+}
+
+#endif // NATIVE_BUILD


### PR DESCRIPTION
## Summary

Registers all 5 remaining FDN minigames as functional stubs in the shared infrastructure files, unblocking Phase 2 parallel development.

- **Ghost Runner** (App ID 4, States 300+) — cyan/teal LED palette
- **Spike Vector** (App ID 5, States 400+) — yellow/orange LED palette
- **Cipher Path** (App ID 6, States 500+) — green/lime LED palette
- **Exploit Sequencer** (App ID 7, States 600+) — red/crimson LED palette
- **Breach Defense** (App ID 8, States 700+) — blue/silver LED palette

Each stub has: Intro → auto-win → terminal state (return to FDN in managed mode, loop in standalone). All 5 integrate with FDN detection, re-encounter prompts, color profile rewards, and CLI simulator.

### Changes
- **35 new files**: 5 games × (header + states header + 4 source files + test header)
- **7 modified files**: `device-types.hpp`, `color-profiles.hpp`, `fdn-detected-state.cpp`, `fdn-reencounter-state.cpp`, `cli-device.hpp`, `cli-tests.cpp`, `progression-core-tests.hpp`

### Tests
- **281 CLI tests passing** (246 existing + 35 new — 7 per game)
- **68 core tests passing** (SIGABRT is pre-existing)
- Test coverage per game: intro state, auto-win, managed mode return, standalone loop, FDN launch via serial, app ID registration, state names

Fixes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)