### PR TITLE
Disconnect recovery with ConnectionLost state (#54)

### DIFF
--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -41,7 +41,8 @@ enum QuickdrawStateId {
     COLOR_PROFILE_PROMPT = 23,
     COLOR_PROFILE_PICKER = 24,
     FDN_REENCOUNTER = 25,
-    KONAMI_PUZZLE = 26
+    KONAMI_PUZZLE = 26,
+    CONNECTION_LOST = 27
 };
 
 class PlayerRegistration : public State {
@@ -281,6 +282,7 @@ public:
     bool transitionToFdnComplete();
     bool transitionToReencounter();
     bool transitionToKonamiPuzzle();
+    bool transitionToConnectionLost();
 
 private:
     Player* player;
@@ -290,6 +292,7 @@ private:
     bool transitionToFdnCompleteState = false;
     bool transitionToReencounterState = false;
     bool transitionToKonamiPuzzleState = false;
+    bool transitionToConnectionLostState = false;
     bool fackReceived = false;
     bool macSent = false;
     bool handshakeComplete = false;
@@ -789,4 +792,32 @@ private:
     std::vector<KonamiButton> targetSequence;
     std::vector<KonamiButton> enteredSequence;
     std::vector<KonamiButton> unlockedButtons;
+};
+
+/*
+ * ConnectionLost — Displayed when serial connection is lost during FDN interaction.
+ * Shows "SIGNAL LOST" message with fast red LED pulse (3 blinks).
+ * After 3 seconds, transitions back to Idle state.
+ * Future enhancement: add retry prompt with cached FDN context.
+ */
+class ConnectionLost : public State {
+public:
+    explicit ConnectionLost(Player* player);
+    ~ConnectionLost();
+
+    void onStateMounted(Device* PDN) override;
+    void onStateLoop(Device* PDN) override;
+    void onStateDismounted(Device* PDN) override;
+
+    bool transitionToIdle();
+
+private:
+    Player* player;
+    SimpleTimer displayTimer;
+    SimpleTimer ledTimer;
+    static constexpr int DISPLAY_DURATION_MS = 3000;
+    static constexpr int LED_BLINK_INTERVAL_MS = 150;
+    static constexpr int BLINK_COUNT = 3;
+    bool transitionToIdleState = false;
+    int blinkCount = 0;
 };

--- a/src/game/quickdraw-states/connection-lost-state.cpp
+++ b/src/game/quickdraw-states/connection-lost-state.cpp
@@ -1,0 +1,93 @@
+#include "game/quickdraw-states.hpp"
+#include "game/quickdraw.hpp"
+#include "device/drivers/logger.hpp"
+#include "device/device-types.hpp"
+
+static const char* TAG = "ConnectionLost";
+
+ConnectionLost::ConnectionLost(Player* player) :
+    State(CONNECTION_LOST),
+    player(player)
+{
+}
+
+ConnectionLost::~ConnectionLost() {
+    player = nullptr;
+}
+
+void ConnectionLost::onStateMounted(Device* PDN) {
+    LOG_W(TAG, "Connection lost - serial timeout");
+
+    transitionToIdleState = false;
+    blinkCount = 0;
+
+    // Display "SIGNAL LOST" message
+    PDN->getDisplay()->invalidateScreen();
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+    PDN->getDisplay()->drawText("SIGNAL LOST", 10, 25);
+    PDN->getDisplay()->render();
+
+    // Start display timer (3 seconds)
+    displayTimer.setTimer(DISPLAY_DURATION_MS);
+
+    // Start LED blink timer
+    ledTimer.setTimer(LED_BLINK_INTERVAL_MS);
+
+    // Start with LED on (red transmit light)
+    AnimationConfig config;
+    config.type = AnimationType::IDLE;
+    config.loop = false;
+    config.speed = 0;
+    config.initialState = LEDState();
+    config.initialState.transmitLight = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+    PDN->getLightManager()->startAnimation(config);
+}
+
+void ConnectionLost::onStateLoop(Device* PDN) {
+    // Update timers
+    displayTimer.updateTime();
+    ledTimer.updateTime();
+
+    // Handle LED blinking (fast red pulse - 3 blinks)
+    if (ledTimer.expired() && blinkCount < BLINK_COUNT * 2) {
+        blinkCount++;
+
+        AnimationConfig config;
+        config.type = AnimationType::IDLE;
+        config.loop = false;
+        config.speed = 0;
+        config.initialState = LEDState();
+
+        if (blinkCount % 2 == 0) {
+            // Even count: turn LED on (red)
+            config.initialState.transmitLight = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
+        } else {
+            // Odd count: turn LED off
+            config.initialState.transmitLight = LEDState::SingleLEDState(LEDColor(0, 0, 0), 0);
+        }
+
+        PDN->getLightManager()->startAnimation(config);
+        ledTimer.setTimer(LED_BLINK_INTERVAL_MS);
+    }
+
+    // Check if display timer expired
+    if (displayTimer.expired()) {
+        transitionToIdleState = true;
+    }
+}
+
+void ConnectionLost::onStateDismounted(Device* PDN) {
+    displayTimer.invalidate();
+    ledTimer.invalidate();
+
+    // Stop animation and clear LEDs
+    PDN->getLightManager()->stopAnimation();
+    PDN->getLightManager()->clear();
+
+    // Clear any pending challenge data
+    player->clearPendingChallenge();
+}
+
+bool ConnectionLost::transitionToIdle() {
+    return transitionToIdleState;
+}

--- a/src/game/quickdraw-states/fdn-detected-state.cpp
+++ b/src/game/quickdraw-states/fdn-detected-state.cpp
@@ -32,6 +32,7 @@ void FdnDetected::onStateMounted(Device* PDN) {
     transitionToFdnCompleteState = false;
     transitionToReencounterState = false;
     transitionToKonamiPuzzleState = false;
+    transitionToConnectionLostState = false;
     fackReceived = false;
     macSent = false;
     handshakeComplete = false;
@@ -187,8 +188,8 @@ void FdnDetected::onStateLoop(Device* PDN) {
     }
 
     if (timeoutTimer.expired()) {
-        LOG_W(TAG, "FDN handshake timed out");
-        transitionToIdleState = true;
+        LOG_W(TAG, "FDN handshake timed out - connection lost");
+        transitionToConnectionLostState = true;
     }
 }
 
@@ -237,4 +238,8 @@ bool FdnDetected::transitionToReencounter() {
 
 bool FdnDetected::transitionToKonamiPuzzle() {
     return transitionToKonamiPuzzleState;
+}
+
+bool FdnDetected::transitionToConnectionLost() {
+    return transitionToConnectionLostState;
 }

--- a/src/game/quickdraw.cpp
+++ b/src/game/quickdraw.cpp
@@ -65,6 +65,7 @@ void Quickdraw::populateStateMap() {
     ColorProfilePrompt* colorProfilePrompt = new ColorProfilePrompt(player, progressManager);
     ColorProfilePicker* colorProfilePicker = new ColorProfilePicker(player, progressManager);
     KonamiPuzzle* konamiPuzzle = new KonamiPuzzle(player);
+    ConnectionLost* connectionLost = new ConnectionLost(player);
 
     playerRegistration->addTransition(
         new StateTransition(
@@ -153,7 +154,17 @@ void Quickdraw::populateStateMap() {
 
     fdnDetected->addTransition(
         new StateTransition(
+            std::bind(&FdnDetected::transitionToConnectionLost, fdnDetected),
+            connectionLost));
+
+    fdnDetected->addTransition(
+        new StateTransition(
             std::bind(&FdnDetected::transitionToIdle, fdnDetected),
+            idle));
+
+    connectionLost->addTransition(
+        new StateTransition(
+            std::bind(&ConnectionLost::transitionToIdle, connectionLost),
             idle));
 
     fdnReencounter->addTransition(
@@ -323,6 +334,7 @@ void Quickdraw::populateStateMap() {
     stateMap.push_back(colorProfilePrompt);
     stateMap.push_back(colorProfilePicker);
     stateMap.push_back(konamiPuzzle);
+    stateMap.push_back(connectionLost);
 }
 
 Image Quickdraw::getImageForAllegiance(Allegiance allegiance, ImageType whichImage) {


### PR DESCRIPTION
Adds ConnectionLost state with retry prompt for disconnect recovery during FDN encounters. Completes issue #54.