### PR TITLE
Fix inverted button mappings in color picker and konami puzzle

### DIFF
--- a/src/game/quickdraw-states/color-profile-picker.cpp
+++ b/src/game/quickdraw-states/color-profile-picker.cpp
@@ -47,7 +47,7 @@ void ColorProfilePicker::onStateMounted(Device* PDN) {
 
     LOG_I(TAG, "Color picker opened, %zu profiles available", profileList.size());
 
-    // Primary (UP) = equip, Secondary (DOWN) = cycle
+    // Primary (UP) = cycle, Secondary (DOWN) = equip
     parameterizedCallbackFunction equipCb = [](void* ctx) {
         auto* self = static_cast<ColorProfilePicker*>(ctx);
         int selected = self->profileList[self->cursorIndex];
@@ -66,8 +66,8 @@ void ColorProfilePicker::onStateMounted(Device* PDN) {
         self->displayIsDirty = true;
     };
 
-    PDN->getPrimaryButton()->setButtonPress(equipCb, this, ButtonInteraction::CLICK);
-    PDN->getSecondaryButton()->setButtonPress(cycleCb, this, ButtonInteraction::CLICK);
+    PDN->getPrimaryButton()->setButtonPress(cycleCb, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(equipCb, this, ButtonInteraction::CLICK);
 
     renderUi(PDN);
 }
@@ -117,6 +117,6 @@ void ColorProfilePicker::renderUi(Device* PDN) {
         }
     }
 
-    PDN->getDisplay()->drawText("UP:equip DOWN:next", 5, 60);
+    PDN->getDisplay()->drawText("UP:next DOWN:equip", 5, 60);
     PDN->getDisplay()->render();
 }

--- a/src/game/quickdraw-states/konami-puzzle-state.cpp
+++ b/src/game/quickdraw-states/konami-puzzle-state.cpp
@@ -88,8 +88,8 @@ void KonamiPuzzle::onStateMounted(Device* PDN) {
               getKonamiButtonName(state->unlockedButtons[state->selectedInputIndex]));
     };
 
-    PDN->getPrimaryButton()->setButtonPress(primaryCallback, this, ButtonInteraction::CLICK);
-    PDN->getSecondaryButton()->setButtonPress(secondaryCallback, this, ButtonInteraction::CLICK);
+    PDN->getPrimaryButton()->setButtonPress(secondaryCallback, this, ButtonInteraction::CLICK);
+    PDN->getSecondaryButton()->setButtonPress(primaryCallback, this, ButtonInteraction::CLICK);
 
     // Initial render
     renderCodeEntry(PDN);
@@ -178,8 +178,8 @@ void KonamiPuzzle::renderCodeEntry(Device* PDN) {
     PDN->getDisplay()->drawText(buttonName, 35, 35);
 
     // Instructions
-    PDN->getDisplay()->drawText("UP:   Stamp", 5, 50);
-    PDN->getDisplay()->drawText("DOWN: Cycle", 5, 60);
+    PDN->getDisplay()->drawText("UP:   Cycle", 5, 50);
+    PDN->getDisplay()->drawText("DOWN: Stamp", 5, 60);
 
     PDN->getDisplay()->render();
 }


### PR DESCRIPTION
## Summary
- **Color Profile Picker**: UP was equip, DOWN was cycle — now correctly UP=cycle, DOWN=equip
- **Konami Puzzle**: UP was stamp, DOWN was cycle — now correctly UP=cycle, DOWN=stamp
- Updated UI hint text to match new mappings

Both states now follow the project-wide standard: **UP (Primary) = cycle/navigate, DOWN (Secondary) = select/confirm**.

All other menu states (Choose Role, Allegiance Picker, Color Profile Prompt, Confirm Offline) already followed this convention correctly.

## Test plan
- [ ] Run `pio test -e native` — no regressions
- [ ] Manual CLI test: verify color picker cycles on UP, equips on DOWN
- [ ] Manual CLI test: verify konami puzzle cycles buttons on UP, stamps on DOWN