### PR TITLE
Fix demo scripts + allegiance value (#89) (Agent 01, Wave 7)

### DIFF
--- a/demos/all-games-showcase.demo
+++ b/demos/all-games-showcase.demo
@@ -2,6 +2,7 @@
 # Demonstrates each of the 7 minigames played in standalone mode
 # Runtime: ~2 minutes
 # Usage: .pio/build/native_cli/program 1 --script demos/all-games-showcase.demo
+#        (No cable connections needed - standalone challenge mode)
 
 # ========================================
 # GAME 1: Ghost Runner

--- a/demos/duel.demo
+++ b/demos/duel.demo
@@ -2,12 +2,19 @@
 # Demonstrates two players engaging in a face-to-face duel
 # Runtime: ~20 seconds
 # Usage: .pio/build/native_cli/program 2 --script demos/duel.demo
+#        (--auto-cable is optional, script explicitly connects cable)
 
 # Wait for devices to settle into Idle
 wait 3
 
 # Check initial states
 state
+
+# Connect cable between devices
+cable 0 1
+
+# Verify connection
+cable -l
 
 # Device 0 (Hunter) initiates duel by long-pressing primary button
 l 0

--- a/demos/fdn-quickstart.demo
+++ b/demos/fdn-quickstart.demo
@@ -1,13 +1,20 @@
 # FDN Quickstart Demo
 # Demonstrates player encountering NPC, playing Signal Echo, winning, and unlocking Konami button
 # Runtime: ~30 seconds
-# Usage: .pio/build/native_cli/program --npc signal-echo --auto-cable --script demos/fdn-quickstart.demo
+# Usage: .pio/build/native_cli/program --npc signal-echo --script demos/fdn-quickstart.demo
+#        (--auto-cable is optional, script explicitly connects cable)
 
 # Wait for devices to settle into Idle
 wait 3
 
 # Check initial states
 state
+
+# Connect cable between player (device 0) and NPC (device 1)
+cable 0 1
+
+# Verify connection
+cable -l
 
 # NPC broadcasts FDN signal automatically - wait for detection
 wait 2

--- a/demos/full-progression.demo
+++ b/demos/full-progression.demo
@@ -2,6 +2,7 @@
 # Demonstrates completing all 7 FDN minigames, collecting all Konami buttons, and unlocking the boon
 # Runtime: ~3 minutes
 # Usage: .pio/build/native_cli/program 1 --script demos/full-progression.demo
+#        (--auto-cable is optional, script explicitly connects cables)
 
 # Wait for player device to settle
 wait 2
@@ -12,6 +13,7 @@ state
 # ========================================
 add npc ghost-runner
 cable 0 1
+cable -l
 wait 4
 
 # Ghost Runner intro (2s)
@@ -37,6 +39,7 @@ konami 0
 # ========================================
 add npc spike-vector
 cable 0 2
+cable -l
 wait 4
 
 # Spike Vector intro (2s)
@@ -64,6 +67,7 @@ konami 0
 # ========================================
 add npc firewall-decrypt
 cable 0 3
+cable -l
 wait 4
 
 # Firewall Decrypt intro (2s)
@@ -96,6 +100,7 @@ konami 0
 # ========================================
 add npc cipher-path
 cable 0 4
+cable -l
 wait 4
 
 # Cipher Path intro (2s)
@@ -124,6 +129,7 @@ konami 0
 # ========================================
 add npc exploit-sequencer
 cable 0 5
+cable -l
 wait 4
 
 # Exploit Sequencer intro (2s)
@@ -150,6 +156,7 @@ konami 0
 # ========================================
 add npc breach-defense
 cable 0 6
+cable -l
 wait 4
 
 # Breach Defense intro (2s)
@@ -176,6 +183,7 @@ konami 0
 # ========================================
 add npc signal-echo
 cable 0 7
+cable -l
 wait 4
 
 # Signal Echo intro (2s)

--- a/include/cli/cli-device.hpp
+++ b/include/cli/cli-device.hpp
@@ -304,7 +304,7 @@ public:
         playerConfig.id = instance.deviceId;
         playerConfig.name = (isHunter ? "Hunter" : "Bounty") + instance.deviceId;
         playerConfig.isHunter = isHunter;
-        playerConfig.allegiance = 1;  // RESISTANCE
+        playerConfig.allegiance = static_cast<int>(Allegiance::RESISTANCE);
         playerConfig.faction = isHunter ? "Guild" : "Rebels";
         MockHttpServer::getInstance().configurePlayer(instance.deviceId, playerConfig);
         


### PR DESCRIPTION
## Summary
- Fixes allegiance to use Allegiance::RESISTANCE enum instead of hardcoded 1
- Adds explicit cable connection commands to all demo scripts
- Removes dependency on --auto-cable flag
- Retry of closed PR #94

Closes #89

## Agent
Agent 01 (Wave 7 - retry)