### PR TITLE
Fix: Remove redundant setPlatformClock(nullptr) from test TearDown (#142)

### DIFF
--- a/test/test_cli/boon-awarded-tests.hpp
+++ b/test/test_cli/boon-awarded-tests.hpp
@@ -23,7 +23,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/breach-defense-tests.hpp
+++ b/test/test_cli/breach-defense-tests.hpp
@@ -27,7 +27,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -60,7 +59,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/cipher-path-tests.hpp
+++ b/test/test_cli/cipher-path-tests.hpp
@@ -27,7 +27,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -60,7 +59,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/color-profile-tests.hpp
+++ b/test/test_cli/color-profile-tests.hpp
@@ -64,7 +64,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -175,7 +174,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -288,7 +286,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -392,7 +389,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/demo-playtest-tests.hpp
+++ b/test/test_cli/demo-playtest-tests.hpp
@@ -154,7 +154,6 @@ void signalEchoEasyPlaytest(DemoPlaytestSuite* suite) {
         }
 
         totalAttempts += attempts;
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device);
     }
 
@@ -250,7 +249,6 @@ void signalEchoHardPlaytest(DemoPlaytestSuite* suite) {
         }
 
         totalAttempts += attempts;
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device);
     }
 
@@ -348,7 +346,6 @@ void ghostRunnerEasyPlaytest(DemoPlaytestSuite* suite) {
         }
 
         totalAttempts += attempts;
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device);
     }
 
@@ -431,7 +428,6 @@ void ghostRunnerHardPlaytest(DemoPlaytestSuite* suite) {
         }
 
         totalAttempts += attempts;
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device);
     }
 

--- a/test/test_cli/e2e-game-suite-tests.hpp
+++ b/test/test_cli/e2e-game-suite-tests.hpp
@@ -39,7 +39,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/edge-case-tests.hpp
+++ b/test/test_cli/edge-case-tests.hpp
@@ -33,7 +33,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -75,7 +74,6 @@ public:
 
     void TearDown() override {
         SerialCableBroker::getInstance().disconnect(0, 1);
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
     }

--- a/test/test_cli/exploit-sequencer-tests.hpp
+++ b/test/test_cli/exploit-sequencer-tests.hpp
@@ -27,7 +27,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -60,7 +59,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/fdn-game-tests.hpp
+++ b/test/test_cli/fdn-game-tests.hpp
@@ -16,7 +16,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
     }
 

--- a/test/test_cli/fdn-integration-tests.hpp
+++ b/test/test_cli/fdn-integration-tests.hpp
@@ -30,7 +30,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
     }
@@ -179,7 +178,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -386,7 +384,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -520,7 +517,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/firewall-decrypt-tests.hpp
+++ b/test/test_cli/firewall-decrypt-tests.hpp
@@ -99,7 +99,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -373,7 +372,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
     }

--- a/test/test_cli/ghost-runner-tests.hpp
+++ b/test/test_cli/ghost-runner-tests.hpp
@@ -27,7 +27,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -60,7 +59,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/hard-mode-reencounter-tests.hpp
+++ b/test/test_cli/hard-mode-reencounter-tests.hpp
@@ -41,7 +41,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdnFirewall_);
         DeviceFactory::destroyDevice(fdnSignalEcho_);
         DeviceFactory::destroyDevice(player_);

--- a/test/test_cli/konami-button-awarded-tests.hpp
+++ b/test/test_cli/konami-button-awarded-tests.hpp
@@ -40,7 +40,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         delete progressManager;
         DeviceFactory::destroyDevice(player_);
     }

--- a/test/test_cli/konami-code-tests.hpp
+++ b/test/test_cli/konami-code-tests.hpp
@@ -30,7 +30,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/konami-fdn-display-tests.hpp
+++ b/test/test_cli/konami-fdn-display-tests.hpp
@@ -23,7 +23,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/konami-metagame-e2e-tests.hpp
+++ b/test/test_cli/konami-metagame-e2e-tests.hpp
@@ -35,7 +35,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         SerialCableBroker::getInstance().disconnect(0, 1);
         DeviceFactory::destroyDevice(player_);
         DeviceFactory::destroyDevice(fdn_);

--- a/test/test_cli/konami-progression-e2e-tests.hpp
+++ b/test/test_cli/konami-progression-e2e-tests.hpp
@@ -30,7 +30,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/konami-puzzle-tests.hpp
+++ b/test/test_cli/konami-puzzle-tests.hpp
@@ -25,7 +25,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/mastery-replay-tests.hpp
+++ b/test/test_cli/mastery-replay-tests.hpp
@@ -26,7 +26,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -909,7 +909,6 @@ public:
 
     void TearDown() override {
         cli::DeviceFactory::destroyDevice(device_);
-        SimpleTimer::setPlatformClock(nullptr);
         g_logger = nullptr;
         delete globalLogger_;
         delete globalClock_;
@@ -1015,7 +1014,6 @@ public:
         }
         devices_.clear();
 
-        SimpleTimer::setPlatformClock(nullptr);
         g_logger = nullptr;
         delete globalLogger_;
         delete globalClock_;

--- a/test/test_cli/negative-flow-tests.hpp
+++ b/test/test_cli/negative-flow-tests.hpp
@@ -39,7 +39,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(hunter_);
     }
@@ -130,7 +129,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(bounty_);
     }

--- a/test/test_cli/progression-core-tests.hpp
+++ b/test/test_cli/progression-core-tests.hpp
@@ -31,7 +31,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
     }
@@ -158,7 +157,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -471,7 +469,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         for (auto& dev : devices_) {
             DeviceFactory::destroyDevice(dev);
         }

--- a/test/test_cli/progression-e2e-tests.hpp
+++ b/test/test_cli/progression-e2e-tests.hpp
@@ -38,7 +38,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
     }

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -24,7 +24,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -360,7 +359,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         delete globalClock_;
     }
 

--- a/test/test_cli/spike-vector-tests.hpp
+++ b/test/test_cli/spike-vector-tests.hpp
@@ -32,7 +32,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -65,7 +64,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(player_);
     }
 

--- a/test/test_cli/stress-tests.hpp
+++ b/test/test_cli/stress-tests.hpp
@@ -29,7 +29,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 
@@ -71,7 +70,6 @@ public:
     }
 
     void TearDown() override {
-        SimpleTimer::setPlatformClock(nullptr);
         DeviceFactory::destroyDevice(device_);
     }
 


### PR DESCRIPTION
## Summary
- Removed redundant `SimpleTimer::setPlatformClock(nullptr)` from 44 test fixture TearDown methods across 27 files
- `DeviceFactory::destroyDevice()` already handles clock cleanup at the correct time (after device deletion)
- Fixes SIGSEGV caused by nulling clock before device destruction

## Issue
Closes #142

## Pipeline
This fix was produced through the Bug-to-Fix pipeline:
- Bug Detectives (agents 9-12) identified and confirmed the root cause
- Senior Engineer (agent 01) wrote detailed tech doc with all 44 fixtures
- Integration, Performance, and Code Quality Engineers reviewed
- Code Quality Engineer caught that REMOVE (not SWAP) was the correct fix
- Junior Engineer (agent 06) implemented

## Verification
- [x] `pio run -e native_cli_test` builds clean
- [x] `pio run -e native_cli` builds clean
- [x] `pio test -e native_cli_test` — 125/126 pass (same as baseline; 1 pre-existing failure unrelated to this fix)
- [x] No manual `setPlatformClock(nullptr)` calls remain in test TearDown methods

---
*Implemented by Junior Engineer Agent 06, reviewed by fleet pipeline*