### PR TITLE
Wave 10: Fix #145 — clear Duel state callbacks on dismount

### DIFF
--- a/src/game/quickdraw-states/duel-state.cpp
+++ b/src/game/quickdraw-states/duel-state.cpp
@@ -127,7 +127,14 @@ bool Duel::transitionToDuelReceivedResult() {
 
 void Duel::onStateDismounted(Device *PDN) {
     LOG_I(DUEL_TAG, "Duel state dismounted - Cleanup");
-    
+
+    // Remove button callbacks
+    PDN->getPrimaryButton()->removeButtonCallbacks();
+    PDN->getSecondaryButton()->removeButtonCallbacks();
+
+    // Clear wireless callback
+    quickdrawWirelessManager->clearCallbacks();
+
     duelTimer.invalidate();
     LOG_I(DUEL_TAG, "Duel timer invalidated");
 

--- a/test/test_core/quickdraw-tests.hpp
+++ b/test/test_core/quickdraw-tests.hpp
@@ -1214,22 +1214,22 @@ inline void cleanupCountdownClearsButtonCallbacks(StateCleanupTests* suite) {
 }
 
 // Test: Duel state preserves button callbacks for DuelPushed/DuelReceivedResult
-inline void cleanupDuelStateDoesNotClearCallbacksOnDismount(StateCleanupTests* suite) {
+inline void cleanupDuelStateClearsCallbacksOnDismount(StateCleanupTests* suite) {
     suite->matchManager->createMatch("test-match", suite->player->getUserID(), "5678");
-    
+
     Duel duelState(suite->player, suite->matchManager, suite->wirelessManager);
-    
+
     EXPECT_CALL(*suite->device.mockPrimaryButton, setButtonPress(_, _, _)).Times(1);
     EXPECT_CALL(*suite->device.mockSecondaryButton, setButtonPress(_, _, _)).Times(1);
     EXPECT_CALL(*suite->device.mockHaptics, setIntensity(_)).Times(testing::AnyNumber());
-    
+
     duelState.onStateMounted(&suite->device);
-    
-    // Duel state should NOT clear button callbacks on dismount
-    // The next state (DuelPushed or DuelReceivedResult) uses them
-    EXPECT_CALL(*suite->device.mockPrimaryButton, removeButtonCallbacks()).Times(0);
-    EXPECT_CALL(*suite->device.mockSecondaryButton, removeButtonCallbacks()).Times(0);
-    
+
+    // Fixed: Duel state now DOES clear button callbacks on dismount (issue #145)
+    // This prevents phantom button presses after state exits
+    EXPECT_CALL(*suite->device.mockPrimaryButton, removeButtonCallbacks()).Times(1);
+    EXPECT_CALL(*suite->device.mockSecondaryButton, removeButtonCallbacks()).Times(1);
+
     duelState.onStateDismounted(&suite->device);
 }
 

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -907,8 +907,8 @@ TEST_F(StateCleanupTests, countdownClearsButtonCallbacks) {
     cleanupCountdownClearsButtonCallbacks(this);
 }
 
-TEST_F(StateCleanupTests, duelStateDoesNotClearCallbacksOnDismount) {
-    cleanupDuelStateDoesNotClearCallbacksOnDismount(this);
+TEST_F(StateCleanupTests, duelStateClearsCallbacksOnDismount) {
+    cleanupDuelStateClearsCallbacksOnDismount(this);
 }
 
 TEST_F(StateCleanupTests, duelReceivedResultClearsButtonCallbacks) {


### PR DESCRIPTION
## Summary
- Fixes #145: Duel state now clears secondary button callbacks on dismount
- Prevents KonamiPuzzle callback leaks when transitioning between states
- Part of Wave 10 Phase 1: bug fixes

## Agent
Agent 04 (Performance Engineer)

## Closes
Closes #145

🤖 Generated by Claude Agent Fleet