### PR TITLE
Wave 10: Create HandshakeApp sub-application

### DIFF
--- a/include/apps/handshake/handshake-states.hpp
+++ b/include/apps/handshake/handshake-states.hpp
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "game/player.hpp"
+#include "utils/simple-timer.hpp"
+#include "state/state.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+#include "game/match-manager.hpp"
+
+// State IDs for handshake states - must match values in QuickdrawStateId
+constexpr int HANDSHAKE_INITIATE_STATE = 9;
+constexpr int BOUNTY_SEND_CC_STATE = 10;
+constexpr int HUNTER_SEND_ID_STATE = 11;
+
+// Base class for all handshake states
+class BaseHandshakeState : public State {
+public:
+    bool transitionToIdle() {
+        return isTimedOut();
+    }
+
+protected:
+    static SimpleTimer* handshakeTimeout;
+    static bool timeoutInitialized;
+    static const int timeout = 20000;
+
+    explicit BaseHandshakeState(int stateId) : State(stateId) {}
+    ~BaseHandshakeState() override = default;
+
+    static void initTimeout() {
+        if (!handshakeTimeout) handshakeTimeout = new SimpleTimer();
+        handshakeTimeout->setTimer(timeout);
+        timeoutInitialized = true;
+    }
+
+    static bool isTimedOut() {
+        if (!timeoutInitialized || !handshakeTimeout) return false;
+        handshakeTimeout->updateTime();
+        return handshakeTimeout->expired();
+    }
+
+    static void resetTimeout() {
+        timeoutInitialized = false;
+        handshakeTimeout->invalidate();
+    }
+};
+
+class HandshakeInitiateState : public BaseHandshakeState {
+public:
+    explicit HandshakeInitiateState(Player *player);
+    ~HandshakeInitiateState();
+
+    void onStateMounted(Device *PDN) override;
+    void onStateLoop(Device *PDN) override;
+    void onStateDismounted(Device *PDN) override;
+    bool transitionToBountySendCC();
+    bool transitionToHunterSendId();
+
+private:
+    Player* player;
+    SimpleTimer handshakeSettlingTimer;
+    const int HANDSHAKE_SETTLE_TIME = 500;
+    bool transitionToBountySendCCState = false;
+    bool transitionToHunterSendIdState = false;
+};
+
+class BountySendConnectionConfirmedState : public BaseHandshakeState {
+public:
+    BountySendConnectionConfirmedState(Player* player, MatchManager* matchManager, QuickdrawWirelessManager* quickdrawWirelessManager);
+    ~BountySendConnectionConfirmedState();
+    void onQuickdrawCommandReceived(QuickdrawCommand command);
+    void onStateMounted(Device *PDN) override;
+    void onStateLoop(Device *PDN) override;
+    void onStateDismounted(Device *PDN) override;
+    bool transitionToConnectionSuccessful();
+
+private:
+    Player* player;
+    MatchManager* matchManager;
+    QuickdrawWirelessManager* quickdrawWirelessManager;
+    SimpleTimer delayTimer;
+    const int delay = 100;
+    bool transitionToConnectionSuccessfulState = false;
+};
+
+class HunterSendIdState : public BaseHandshakeState {
+public:
+    HunterSendIdState(Player *player, MatchManager* matchManager, QuickdrawWirelessManager* quickdrawWirelessManager);
+    ~HunterSendIdState();
+
+    void onStateMounted(Device *PDN) override;
+    void onStateLoop(Device *PDN) override;
+    void onStateDismounted(Device *PDN) override;
+    void onQuickdrawCommandReceived(QuickdrawCommand command);
+    bool transitionToConnectionSuccessful();
+
+private:
+    Player* player;
+    MatchManager* matchManager;
+    QuickdrawWirelessManager* quickdrawWirelessManager;
+    SimpleTimer delayTimer;
+    const int delay = 100;
+    bool transitionToConnectionSuccessfulState = false;
+};

--- a/include/apps/handshake/handshake.hpp
+++ b/include/apps/handshake/handshake.hpp
@@ -1,0 +1,21 @@
+#pragma once
+#include "state/state-machine.hpp"
+#include "apps/handshake/handshake-states.hpp"
+
+class HandshakeApp : public StateMachine {
+public:
+    HandshakeApp(Player* player, MatchManager* matchManager,
+                 QuickdrawWirelessManager* quickdrawWirelessManager);
+    ~HandshakeApp() override;
+    void populateStateMap() override;
+
+    bool readyForCountdown() const;
+    bool timedOut() const;
+
+private:
+    Player* player;
+    MatchManager* matchManager;
+    QuickdrawWirelessManager* quickdrawWirelessManager;
+    bool handshakeComplete = false;
+    bool handshakeTimedOut = false;
+};

--- a/platformio.ini
+++ b/platformio.ini
@@ -89,6 +89,7 @@ build_src_filter =
     -<native-main.cpp>
     -<cli-main.cpp>
     -<device/drivers/esp32-s3/*>
+    -<game/quickdraw-states/handshake-states/*>
 
 lib_deps =
     googletest
@@ -117,6 +118,7 @@ build_src_filter =
     -<main.cpp>
     -<native-main.cpp>
     -<device/drivers/esp32-s3/*>
+    -<game/quickdraw-states/handshake-states/*>
 
 lib_deps = 
     bblanchon/ArduinoJson@^7.4.2
@@ -148,6 +150,7 @@ build_src_filter =
     -<native-main.cpp>
     -<cli-main.cpp>
     -<device/drivers/esp32-s3/*>
+    -<game/quickdraw-states/handshake-states/*>
 
 lib_deps =
     googletest

--- a/src/apps/handshake/base-handshake-state.cpp
+++ b/src/apps/handshake/base-handshake-state.cpp
@@ -1,0 +1,5 @@
+#include "apps/handshake/handshake-states.hpp"
+
+// Define static members of BaseHandshakeState
+SimpleTimer* BaseHandshakeState::handshakeTimeout = nullptr;
+bool BaseHandshakeState::timeoutInitialized = false; 

--- a/src/apps/handshake/bounty-send-cc.cpp
+++ b/src/apps/handshake/bounty-send-cc.cpp
@@ -1,0 +1,136 @@
+#include "apps/handshake/handshake-states.hpp"
+#include "id-generator.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+#include "game/match-manager.hpp"
+
+
+BountySendConnectionConfirmedState::BountySendConnectionConfirmedState(Player *player, MatchManager* matchManager, QuickdrawWirelessManager* quickdrawWirelessManager) : BaseHandshakeState(BOUNTY_SEND_CC_STATE) {
+    this->matchManager = matchManager;
+    this->player = player;
+    this->quickdrawWirelessManager = quickdrawWirelessManager;
+}
+
+BountySendConnectionConfirmedState::~BountySendConnectionConfirmedState() {
+    player = nullptr;
+    matchManager = nullptr;
+    quickdrawWirelessManager = nullptr;
+}
+
+
+
+void BountySendConnectionConfirmedState::onStateMounted(Device *PDN) {
+    if (!player) {
+        LOG_E("BOUNTY_SEND_CC", "Player is null in onStateMounted");
+        return;
+    }
+
+    if (player->getOpponentMacAddress().empty()) {
+        LOG_E("BOUNTY_SEND_CC", "Opponent MAC address is empty");
+        return;
+    }
+
+    LOG_I("BOUNTY_SEND_CC", "State mounted");
+    
+    std::string bountyId = player->getUserID();
+    if (bountyId.empty()) {
+        LOG_E("BOUNTY_SEND_CC", "Player ID is empty");
+        return;
+    }
+
+    std::string matchId = IdGenerator(SimpleTimer::getPlatformClock()->milliseconds()).generateId();
+    if (matchId.empty()) {
+        LOG_E("BOUNTY_SEND_CC", "Failed to generate match ID");
+        return;
+    }
+    
+    LOG_I("BOUNTY_SEND_CC", "Broadcasting packet with matchId: %s, bountyId: %s", 
+             matchId.c_str(), bountyId.c_str());
+    
+    quickdrawWirelessManager->setPacketReceivedCallback(
+        std::bind(&BountySendConnectionConfirmedState::onQuickdrawCommandReceived, this, std::placeholders::_1)
+    );
+
+    try {
+        Match initialMatch(matchId, "", bountyId);  // Empty hunter ID initially
+        quickdrawWirelessManager->broadcastPacket(
+            player->getOpponentMacAddress(),
+            CONNECTION_CONFIRMED,
+            initialMatch
+        );
+        LOG_I("BOUNTY_SEND_CC", "Sent CONNECTION_CONFIRMED");
+    } catch (const std::exception& e) {
+        LOG_E("BOUNTY_SEND_CC", "Failed to send CONNECTION_CONFIRMED: %s", e.what());
+    }
+}
+
+void BountySendConnectionConfirmedState::onQuickdrawCommandReceived(QuickdrawCommand command) {
+    if (!player) {
+        LOG_E("BOUNTY_SEND_CC", "Player is null in command handler");
+        return;
+    }
+
+    if (player->getOpponentMacAddress().empty()) {
+        LOG_E("BOUNTY_SEND_CC", "Opponent MAC address is empty");
+        return;
+    }
+
+    LOG_I("BOUNTY_SEND_CC", "Received command: %d", command.command);
+    
+    if (command.command == HUNTER_RECEIVE_MATCH) {
+        LOG_I("BOUNTY_SEND_CC", "Received HUNTER_RECEIVE_MATCH command");
+        
+        // Validate received match data
+        if (command.match.getMatchId().empty()) {
+            LOG_E("BOUNTY_SEND_CC", "Received empty match ID");
+            return;
+        }
+        if (command.match.getHunterId().empty()) {
+            LOG_E("BOUNTY_SEND_CC", "Received empty hunter ID");
+            return;
+        }
+        if (command.match.getBountyId().empty()) {
+            LOG_E("BOUNTY_SEND_CC", "Received empty bounty ID");
+            return;
+        }
+
+        LOG_I("BOUNTY_SEND_CC", "Received match - ID: %s, Hunter: %s, Bounty: %s",
+                 command.match.getMatchId().c_str(),
+                 command.match.getHunterId().c_str(),
+                 command.match.getBountyId().c_str());
+
+        Match* match = matchManager->receiveMatch(command.match);
+        if (!match) {
+            LOG_E("BOUNTY_SEND_CC", "Failed to receive match");
+            return;
+        }
+
+        try {
+            quickdrawWirelessManager->broadcastPacket(
+                player->getOpponentMacAddress(),
+                BOUNTY_FINAL_ACK,
+                *match
+            );
+            LOG_I("BOUNTY_SEND_CC", "Sent BOUNTY_FINAL_ACK");
+            transitionToConnectionSuccessfulState = true;
+        } catch (const std::exception& e) {
+            LOG_E("BOUNTY_SEND_CC", "Failed to send BOUNTY_FINAL_ACK: %s", e.what());
+        }
+    } else {
+        LOG_W("BOUNTY_SEND_CC", "Received unexpected command: %d", command.command);
+    }
+}
+
+void BountySendConnectionConfirmedState::onStateLoop(Device *PDN) {
+    
+}
+
+void BountySendConnectionConfirmedState::onStateDismounted(Device *PDN) {
+    transitionToConnectionSuccessfulState = false;
+    LOG_I("BOUNTY_SEND_CC", "State dismounted");
+    BaseHandshakeState::resetTimeout();
+    quickdrawWirelessManager->clearCallbacks();
+}
+
+bool BountySendConnectionConfirmedState::transitionToConnectionSuccessful() {
+    return transitionToConnectionSuccessfulState;
+}

--- a/src/apps/handshake/handshake.cpp
+++ b/src/apps/handshake/handshake.cpp
@@ -1,0 +1,51 @@
+#include "apps/handshake/handshake.hpp"
+#include "state/state.hpp"
+
+// Define a unique app ID for HandshakeApp
+constexpr int HANDSHAKE_APP_ID = 2;
+
+HandshakeApp::HandshakeApp(Player* player, MatchManager* matchManager,
+                           QuickdrawWirelessManager* quickdrawWirelessManager) :
+    StateMachine(HANDSHAKE_APP_ID),
+    player(player),
+    matchManager(matchManager),
+    quickdrawWirelessManager(quickdrawWirelessManager)
+{
+}
+
+HandshakeApp::~HandshakeApp() {
+    player = nullptr;
+    matchManager = nullptr;
+    quickdrawWirelessManager = nullptr;
+}
+
+void HandshakeApp::populateStateMap() {
+    // Create handshake states
+    HandshakeInitiateState* handshakeInitiate = new HandshakeInitiateState(player);
+    BountySendConnectionConfirmedState* bountySendCC = new BountySendConnectionConfirmedState(player, matchManager, quickdrawWirelessManager);
+    HunterSendIdState* hunterSendId = new HunterSendIdState(player, matchManager, quickdrawWirelessManager);
+
+    // Add states to state map
+    stateMap.push_back(handshakeInitiate);
+    stateMap.push_back(bountySendCC);
+    stateMap.push_back(hunterSendId);
+
+    // Configure transitions
+    handshakeInitiate->addTransition(
+        new StateTransition(
+            std::bind(&HandshakeInitiateState::transitionToBountySendCC, handshakeInitiate),
+            bountySendCC));
+
+    handshakeInitiate->addTransition(
+        new StateTransition(
+            std::bind(&HandshakeInitiateState::transitionToHunterSendId, handshakeInitiate),
+            hunterSendId));
+}
+
+bool HandshakeApp::readyForCountdown() const {
+    return handshakeComplete;
+}
+
+bool HandshakeApp::timedOut() const {
+    return handshakeTimedOut;
+}

--- a/src/apps/handshake/hunter-send-id.cpp
+++ b/src/apps/handshake/hunter-send-id.cpp
@@ -1,0 +1,102 @@
+#include "id-generator.hpp"
+#include "apps/handshake/handshake-states.hpp"
+#include "wireless/quickdraw-wireless-manager.hpp"
+#include "game/match-manager.hpp"
+// Opening Handshake State for a Hunter. we have sent our mac address over serial and are waiting
+// for the opponent to send the match id and their user id.
+
+HunterSendIdState::HunterSendIdState(Player *player, MatchManager* matchManager, QuickdrawWirelessManager* quickdrawWirelessManager) : BaseHandshakeState(HUNTER_SEND_ID_STATE) {
+    this->matchManager = matchManager;
+    this->player = player;
+    this->quickdrawWirelessManager = quickdrawWirelessManager;
+}
+
+HunterSendIdState::~HunterSendIdState() {
+    player = nullptr;
+    matchManager = nullptr;
+    quickdrawWirelessManager = nullptr;
+}
+
+
+void HunterSendIdState::onStateMounted(Device *PDN) {
+    LOG_I("HUNTER_SEND_ID", "State mounted");
+    quickdrawWirelessManager->setPacketReceivedCallback(std::bind(&HunterSendIdState::onQuickdrawCommandReceived, this, std::placeholders::_1));
+}
+
+void HunterSendIdState::onQuickdrawCommandReceived(QuickdrawCommand command) {
+    if (!player) {
+        LOG_E("HUNTER_SEND_ID", "Player is null in command handler");
+        return;
+    }
+
+    LOG_I("HUNTER_SEND_ID", "Command received: %d", command.command);
+    
+    if (command.command == CONNECTION_CONFIRMED) {
+        LOG_I("HUNTER_SEND_ID", "Received CONNECTION_CONFIRMED from opponent");
+        
+        // Validate received match data
+        if (command.match.getMatchId().empty()) {
+            LOG_E("HUNTER_SEND_ID", "Received empty match ID");
+            return;
+        }
+        if (command.match.getBountyId().empty()) {
+            LOG_E("HUNTER_SEND_ID", "Received empty bounty ID");
+            return;
+        }
+        
+        LOG_I("HUNTER_SEND_ID", "Received match ID: %s, bounty ID: %s", 
+                 command.match.getMatchId().c_str(), 
+                 command.match.getBountyId().c_str());
+
+        // Set opponent MAC address
+        if (command.wifiMacAddr.empty()) {
+            LOG_E("HUNTER_SEND_ID", "Received empty MAC address");
+            return;
+        }
+        player->setOpponentMacAddress(command.wifiMacAddr);
+        
+        // Create new match with validated data
+        Match* newMatch = matchManager->createMatch(
+            command.match.getMatchId(),
+            player->getUserID(),
+            command.match.getBountyId()
+        );
+        
+        if (!newMatch) {
+            LOG_E("HUNTER_SEND_ID", "Failed to create match");
+            return;
+        }
+
+        LOG_I("HUNTER_SEND_ID", "Created match with ID: %s", newMatch->getMatchId().c_str());
+        
+        try {
+            quickdrawWirelessManager->broadcastPacket(
+                player->getOpponentMacAddress(),
+                HUNTER_RECEIVE_MATCH,
+                *newMatch
+            );
+            LOG_I("HUNTER_SEND_ID", "Sent HUNTER_RECEIVE_MATCH");
+        } catch (const std::exception& e) {
+            LOG_E("HUNTER_SEND_ID", "Failed to send HUNTER_RECEIVE_MATCH: %s", e.what());
+        }
+    } else if (command.command == BOUNTY_FINAL_ACK) {
+        LOG_I("HUNTER_SEND_ID", "Received BOUNTY_FINAL_ACK from opponent");
+        transitionToConnectionSuccessfulState = true;
+    } else {
+        LOG_W("HUNTER_SEND_ID", "Received unexpected command: %d", command.command);
+    }
+}
+
+
+void HunterSendIdState::onStateLoop(Device *PDN) {}
+
+void HunterSendIdState::onStateDismounted(Device *PDN) {
+    LOG_I("HUNTER_SEND_ID", "State dismounted");
+    transitionToConnectionSuccessfulState = false;
+    BaseHandshakeState::resetTimeout();
+    quickdrawWirelessManager->clearCallbacks();
+}
+
+bool HunterSendIdState::transitionToConnectionSuccessful() {
+    return transitionToConnectionSuccessfulState;
+}

--- a/src/apps/handshake/initiate-state.cpp
+++ b/src/apps/handshake/initiate-state.cpp
@@ -1,0 +1,40 @@
+#include "apps/handshake/handshake-states.hpp"
+#include "device/wireless-manager.hpp"
+
+HandshakeInitiateState::HandshakeInitiateState(Player *player) : BaseHandshakeState(HANDSHAKE_INITIATE_STATE) {
+    this->player = player;
+}
+
+HandshakeInitiateState::~HandshakeInitiateState() {
+    player = nullptr;
+}
+
+void HandshakeInitiateState::onStateMounted(Device *PDN) {
+    LOG_I("INITIATE_STATE", "State mounted");
+}
+
+void HandshakeInitiateState::onStateLoop(Device *PDN) {
+    BaseHandshakeState::initTimeout();
+    if(player->isHunter()) {
+        LOG_I("INITIATE_STATE", "Player is Hunter, transitioning to HunterSendIdState");
+        transitionToHunterSendIdState = true;
+    } else {
+        LOG_I("INITIATE_STATE", "Transitioning to BountySendCCState");
+        transitionToBountySendCCState = true;
+    }
+}
+
+void HandshakeInitiateState::onStateDismounted(Device *PDN) {
+    LOG_I("INITIATE_STATE", "State dismounted");
+    transitionToBountySendCCState = false;
+    transitionToHunterSendIdState = false;
+}
+
+bool HandshakeInitiateState::transitionToBountySendCC() {
+    return transitionToBountySendCCState;
+} 
+
+
+bool HandshakeInitiateState::transitionToHunterSendId() {
+    return transitionToHunterSendIdState;
+}


### PR DESCRIPTION
## Summary
- Creates `HandshakeApp` sub-application to handle serial handshake/connection flow
- Extracts handshake logic from monolithic quickdraw state machine into standalone sub-app
- Part of Wave 10 Phase 1: sub-app extraction

## Agent
Agent 09 (Promoted Detective)

## Related
Wave 10 Phase 1 — PR #90 integration + sub-app extraction

🤖 Generated by Claude Agent Fleet