### PR TITLE
Wave 11: Fix MatchManager memory leak in Quickdraw destructor

### DIFF
--- a/src/game/quickdraw.cpp
+++ b/src/game/quickdraw.cpp
@@ -18,6 +18,7 @@ Quickdraw::Quickdraw(Player* player, Device* PDN, QuickdrawWirelessManager* quic
 Quickdraw::~Quickdraw() {
     player = nullptr;
     quickdrawWirelessManager = nullptr;
+    delete matchManager;
     matchManager = nullptr;
     storageManager = nullptr;
     peerComms = nullptr;

--- a/test/test_core/tests.cpp
+++ b/test/test_core/tests.cpp
@@ -956,6 +956,14 @@ TEST_F(ConnectionSuccessfulTests, transitionsAfterThreshold) {
 }
 
 // ============================================
+// QUICKDRAW DESTRUCTOR TESTS
+// ============================================
+
+TEST_F(QuickdrawDestructorTests, destructorCleansUpMatchManager) {
+    quickdrawDestructorCleansUpMatchManager(this);
+}
+
+// ============================================
 // QUICKDRAW INTEGRATION TESTS - PACKET PARSING
 // ============================================
 


### PR DESCRIPTION
Automated stability fix from Wave 11 dispatch.