### PR TITLE
Wave 11: Add null guard to StateMachine::commitState()

### DIFF
--- a/include/state/state-machine.hpp
+++ b/include/state/state-machine.hpp
@@ -2,6 +2,7 @@
 
 #include <vector>
 #include "device/device.hpp"
+#include "device/drivers/logger.hpp"
 #include "state.hpp"
 
 /*
@@ -75,9 +76,29 @@ public:
     void checkStateTransitions() {
         newState = currentState->checkTransitions();
         stateChangeReady = (newState != nullptr);
+
+        #ifdef DEBUG
+        // Debug assertion - validate state transitions during development
+        if (stateChangeReady && newState == nullptr) {
+            LOG_E("StateMachine", "ASSERTION FAILED: stateChangeReady true but newState is null");
+        }
+        #endif
     };
 
     void commitState(Device *PDN) {
+        if (newState == nullptr) {
+            LOG_W("StateMachine", "commitState called with null newState - skipping transition");
+            stateChangeReady = false;
+            return;
+        }
+
+        #ifdef DEBUG
+        // Debug assertion - catch null transitions during development
+        if (newState == nullptr) {
+            LOG_E("StateMachine", "ASSERTION FAILED: commitState() received null state pointer");
+        }
+        #endif
+
         currentState->onStateDismounted(PDN);
 
         currentState = newState;

--- a/test/test_core/state-machine-tests.hpp
+++ b/test/test_core/state-machine-tests.hpp
@@ -262,6 +262,38 @@ public:
     }
 };
 
+class NullStateTestMachine : public StateMachine {
+public:
+    NullStateTestMachine() : StateMachine(0) {}
+
+    void populateStateMap() override {
+        InitialTestState *initialState = new InitialTestState();
+
+        // Add a transition that points to nullptr (simulating invalid state)
+        initialState->addTransition(
+            new StateTransition(
+                std::bind(&InitialTestState::transitionToSecondState, initialState),
+                nullptr));
+
+        stateMap.push_back(initialState);
+    }
+
+    bool getTransitionReadyFlag() {
+        return stateChangeReady;
+    }
+
+    State* getNewState() {
+        return newState;
+    }
+
+    // Test helper to manually trigger commitState with null
+    void forceCommitWithNull(Device* PDN) {
+        newState = nullptr;
+        stateChangeReady = true;
+        commitState(PDN);
+    }
+};
+
 class StateMachineTestSuite : public testing::Test {
 
 protected:


### PR DESCRIPTION
Automated stability fix from Wave 11 dispatch.