### PR TITLE
Wave 11: Fix driver leaks in native-main + static timer leak

### DIFF
--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -633,7 +633,7 @@ public:
     }
 
 protected:
-    static SimpleTimer* handshakeTimeout;
+    static SimpleTimer handshakeTimeout;
     static bool timeoutInitialized;
     static const int timeout = 20000;
 
@@ -641,20 +641,19 @@ protected:
     ~BaseHandshakeState() override = default;
 
     static void initTimeout() {
-        if (!handshakeTimeout) handshakeTimeout = new SimpleTimer();
-        handshakeTimeout->setTimer(timeout);
+        handshakeTimeout.setTimer(timeout);
         timeoutInitialized = true;
     }
 
     static bool isTimedOut() {
-        if (!timeoutInitialized || !handshakeTimeout) return false;
-        handshakeTimeout->updateTime();
-        return handshakeTimeout->expired();
+        if (!timeoutInitialized) return false;
+        handshakeTimeout.updateTime();
+        return handshakeTimeout.expired();
     }
 
     static void resetTimeout() {
         timeoutInitialized = false;
-        handshakeTimeout->invalidate();
+        handshakeTimeout.invalidate();
     }
 };
 

--- a/src/game/quickdraw-states/handshake-states/base-handshake-state.cpp
+++ b/src/game/quickdraw-states/handshake-states/base-handshake-state.cpp
@@ -1,5 +1,5 @@
 #include "game/quickdraw-states.hpp"
 
 // Define static members of BaseHandshakeState
-SimpleTimer* BaseHandshakeState::handshakeTimeout = nullptr;
+SimpleTimer BaseHandshakeState::handshakeTimeout;
 bool BaseHandshakeState::timeoutInitialized = false; 

--- a/src/native-main.cpp
+++ b/src/native-main.cpp
@@ -248,12 +248,14 @@ int main(int argc, char** argv) {
     for (auto& device : devices) {
         delete device.game;
         delete device.player;
-        delete device.pdn;
+        delete device.pdn;  // This deletes drivers via DriverManager::dismountDrivers()
+        // Note: drivers are deleted by PDN's destructor, so we don't delete them here
     }
-    
+
+    // Clean up global drivers (these are NOT owned by any PDN instance)
     delete globalLogger;
     delete globalClock;
-    
+
     return 0;
 }
 


### PR DESCRIPTION
Automated stability fix from Wave 11 dispatch.