### PR TITLE
Fix CLI test SIGABRT: pure virtual call in Device destructor

### DIFF
--- a/include/cli/cli-device.hpp
+++ b/include/cli/cli-device.hpp
@@ -416,10 +416,13 @@ public:
         // State dismount callbacks may call SimpleTimer::updateTime() which needs valid clock or nullptr
         SimpleTimer::setPlatformClock(nullptr);
 
-        // Note: device.game and minigames are now deleted by PDN destructor (Device::~Device)
+        // Delete PDN first — its destructor dismounts apps, which may call
+        // quickdrawWirelessManager->clearCallbacks(). Must happen before
+        // deleting the wireless manager.
+        delete device.pdn;
+        // Note: device.game and minigames are deleted by PDN destructor
         delete device.quickdrawWirelessManager;
         delete device.player;
-        delete device.pdn;
         // Note: drivers are owned by DriverManager via PDN, so they're deleted when PDN is deleted
     }
 

--- a/include/device/device.hpp
+++ b/include/device/device.hpp
@@ -51,6 +51,7 @@ public:
     virtual WirelessManager* getWirelessManager() = 0;
 
 protected:
+    void shutdownApps();
     explicit Device(const DriverConfig& deviceConfig) : driverManager(deviceConfig) {
         driverManager.initialize();
     }

--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -6,9 +6,15 @@
 const char* TAG = "Device";
 
 Device::~Device() {
-    // Dismount launched apps before deletion to ensure active state cleanup
-    // (timers, callbacks, resources) runs properly. Only dismount apps that
-    // were actually launched to respect the mount/dismount lifecycle contract.
+    // shutdownApps() is called here for test mocks and simple Device subclasses.
+    // For PDN, shutdownApps() is called first in PDN::~PDN() (while the vtable
+    // still has PDN's virtual method implementations). The second call here is
+    // a no-op since shutdownApps() clears appConfig after processing.
+    shutdownApps();
+    driverManager.dismountDrivers();
+}
+
+void Device::shutdownApps() {
     for (auto& pair : appConfig) {
         if (pair.second != nullptr) {
             if (pair.second->hasLaunched()) {
@@ -19,7 +25,6 @@ Device::~Device() {
         }
     }
     appConfig.clear();
-    driverManager.dismountDrivers();
 }
 
 void Device::loadAppConfig(AppConfig config, StateId launchAppId) {

--- a/src/device/pdn.cpp
+++ b/src/device/pdn.cpp
@@ -7,6 +7,10 @@ PDN* PDN::createPDN(DriverConfig& driverConfig) {
 }
 
 PDN::~PDN() {
+    // Dismount apps here (not in ~Device) because state dismount callbacks
+    // may call virtual methods like getHaptics(). During ~Device(), the vtable
+    // reverts to Device's pure virtual definitions, causing SIGABRT.
+    shutdownApps();
 }
 
 PDN::PDN(DriverConfig& driverConfig) : Device(driverConfig) {


### PR DESCRIPTION
## Summary
- Root cause: `Device::~Device()` dismounts apps via `onStateDismounted(this)`, but by then `PDN::~PDN()` has already run and the vtable reverted to `Device`'s pure virtual definitions. States calling `PDN->getHaptics()->off()` during dismount hit `__cxa_pure_virtual`.
- Fix: Extract app dismounting into `Device::shutdownApps()`, call from `PDN::~PDN()` (vtable still intact). Idempotent call in `~Device()` handles test mocks.
- Also fixes destruction order in `DeviceFactory::destroyDevice()` — PDN must be deleted before `QuickdrawWirelessManager`.
- **CLI tests went from 3/4 passing to 123/126** — the SIGABRT was killing the process at test 4, blocking 122 tests from ever running.

## Test plan
- [x] 221/221 native tests passing
- [x] 123/126 CLI tests passing (3 pre-existing issues unmasked, tracked separately)
- [x] GDB confirmed crash at `BreachDefenseShow::onStateDismounted` → `Device::~Device` vtable reversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)