### PR TITLE
Wave 12: Fix #143 — FdnDetected stuck in CONNECTING

### DIFF
--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -288,6 +288,7 @@ private:
     bool fackReceived = false;
     bool macSent = false;
     bool handshakeComplete = false;
+    bool gameLaunched = false;
     std::string fdnMessage;
     GameType pendingGameType = GameType::QUICKDRAW;
     KonamiButton pendingReward = KonamiButton::UP;
@@ -297,6 +298,7 @@ struct FdnDetectedSnapshot : public Snapshot {
     GameType gameType = GameType::QUICKDRAW;
     KonamiButton reward = KonamiButton::UP;
     bool handshakeComplete = false;
+    bool gameLaunched = false;
 };
 
 /*

--- a/src/game/quickdraw-states/fdn-detected-state.cpp
+++ b/src/game/quickdraw-states/fdn-detected-state.cpp
@@ -40,6 +40,7 @@ void FdnDetected::onStateMounted(Device* PDN) {
     fackReceived = false;
     macSent = false;
     handshakeComplete = false;
+    gameLaunched = false;
 
     // Read the pending FDN message from Player (set by Idle)
     fdnMessage = player->getPendingCdevMessage();
@@ -142,6 +143,7 @@ void FdnDetected::onStateLoop(Device* PDN) {
 
         player->setRecreationalMode(false);
         game->resetGame();
+        gameLaunched = true;
         PDN->setActiveApp(StateId(appId));
         return;
     }
@@ -166,6 +168,7 @@ std::unique_ptr<Snapshot> FdnDetected::onStatePaused(Device* PDN) {
     snapshot->gameType = pendingGameType;
     snapshot->reward = pendingReward;
     snapshot->handshakeComplete = handshakeComplete;
+    snapshot->gameLaunched = gameLaunched;
     return snapshot;
 }
 
@@ -175,10 +178,11 @@ void FdnDetected::onStateResumed(Device* PDN, Snapshot* snapshot) {
         pendingGameType = fdnSnapshot->gameType;
         pendingReward = fdnSnapshot->reward;
         handshakeComplete = fdnSnapshot->handshakeComplete;
+        gameLaunched = fdnSnapshot->gameLaunched;
     }
 
-    // If handshake was complete when we paused, the minigame is done
-    if (handshakeComplete) {
+    // If we launched a game and it's now done, transition to FdnComplete
+    if (gameLaunched) {
         transitionToFdnCompleteState = true;
     }
 }


### PR DESCRIPTION
Fixes #143. Relates to #175. Tracks gameLaunched flag in FdnDetected to properly transition to FdnComplete after minigame completes.