### PR TITLE
Wave 12: Refactor #167 Phase 1 — move seedRng() to MiniGame base

### DIFF
--- a/include/game/breach-defense/breach-defense.hpp
+++ b/include/game/breach-defense/breach-defense.hpp
@@ -72,8 +72,6 @@ public:
     BreachDefenseConfig& getConfig() { return config; }
     BreachDefenseSession& getSession() { return session; }
 
-    void seedRng();
-
 private:
     BreachDefenseConfig config;
     BreachDefenseSession session;

--- a/include/game/cipher-path/cipher-path.hpp
+++ b/include/game/cipher-path/cipher-path.hpp
@@ -75,7 +75,6 @@ public:
     CipherPathConfig& getConfig() { return config; }
     CipherPathSession& getSession() { return session; }
 
-    void seedRng();
     void generateCipher();  // fills session.cipher[] with random 0/1 values
 
 private:

--- a/include/game/exploit-sequencer/exploit-sequencer.hpp
+++ b/include/game/exploit-sequencer/exploit-sequencer.hpp
@@ -87,8 +87,6 @@ public:
     ExploitSequencerConfig& getConfig() { return config; }
     ExploitSequencerSession& getSession() { return session; }
 
-    void seedRng();
-
 private:
     ExploitSequencerConfig config;
     ExploitSequencerSession session;

--- a/include/game/firewall-decrypt/firewall-decrypt.hpp
+++ b/include/game/firewall-decrypt/firewall-decrypt.hpp
@@ -87,8 +87,6 @@ public:
      */
     void setupRound();
 
-    void seedRng();
-
 private:
     FirewallDecryptConfig config;
     FirewallDecryptSession session;

--- a/include/game/ghost-runner/ghost-runner.hpp
+++ b/include/game/ghost-runner/ghost-runner.hpp
@@ -83,13 +83,6 @@ public:
     GhostRunnerConfig& getConfig() { return config; }
     GhostRunnerSession& getSession() { return session; }
 
-    /*
-     * Seed the PRNG. Called once during initialization.
-     * If config.rngSeed != 0, uses that seed (deterministic for tests).
-     * Otherwise uses 0.
-     */
-    void seedRng();
-
 private:
     GhostRunnerConfig config;
     GhostRunnerSession session;

--- a/include/game/minigame.hpp
+++ b/include/game/minigame.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <cstdlib>
 #include "state/state-machine.hpp"
 #include "device/device-types.hpp"
 
@@ -59,6 +60,19 @@ public:
 
     void setStartTime(uint32_t timeMs) {
         outcome.startTimeMs = timeMs;
+    }
+
+    /*
+     * Seed the PRNG. Should be called once during initialization (e.g., in populateStateMap).
+     * If the minigame config has a nonzero rngSeed, uses that seed (deterministic for tests).
+     * Otherwise uses 0 (production would use MAC address or time-based, but standalone falls back to 0).
+     */
+    void seedRng(unsigned long rngSeed) {
+        if (rngSeed != 0) {
+            srand(static_cast<unsigned int>(rngSeed));
+        } else {
+            srand(static_cast<unsigned int>(0));
+        }
     }
 
 protected:

--- a/include/game/signal-echo/signal-echo.hpp
+++ b/include/game/signal-echo/signal-echo.hpp
@@ -72,14 +72,6 @@ public:
      */
     std::vector<bool> generateSequence(int length);
 
-    /*
-     * Seed the PRNG. Called once during initialization.
-     * If config.rngSeed != 0, uses that seed (deterministic for tests).
-     * Otherwise uses 0 (production would use MAC address, but standalone
-     * mode falls back to time-based or 0).
-     */
-    void seedRng();
-
 private:
     SignalEchoConfig config;
     SignalEchoSession session;

--- a/include/game/spike-vector/spike-vector.hpp
+++ b/include/game/spike-vector/spike-vector.hpp
@@ -75,8 +75,6 @@ public:
     SpikeVectorConfig& getConfig() { return config; }
     SpikeVectorSession& getSession() { return session; }
 
-    void seedRng();
-
 private:
     SpikeVectorConfig config;
     SpikeVectorSession session;

--- a/src/game/breach-defense/breach-defense-intro.cpp
+++ b/src/game/breach-defense/breach-defense-intro.cpp
@@ -23,7 +23,7 @@ void BreachDefenseIntro::onStateMounted(Device* PDN) {
 
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
 
     // Display title screen
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/breach-defense/breach-defense.cpp
+++ b/src/game/breach-defense/breach-defense.cpp
@@ -2,6 +2,8 @@
 #include "game/breach-defense/breach-defense-states.hpp"
 
 void BreachDefense::populateStateMap() {
+    seedRng(config.rngSeed);
+
     BreachDefenseIntro* intro       = new BreachDefenseIntro(this);
     BreachDefenseShow* show         = new BreachDefenseShow(this);
     BreachDefenseGameplay* gameplay = new BreachDefenseGameplay(this);
@@ -66,12 +68,4 @@ void BreachDefense::populateStateMap() {
 void BreachDefense::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void BreachDefense::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }

--- a/src/game/cipher-path/cipher-path-intro.cpp
+++ b/src/game/cipher-path/cipher-path-intro.cpp
@@ -24,7 +24,7 @@ void CipherPathIntro::onStateMounted(Device* PDN) {
 
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
 
     // Display title screen
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/cipher-path/cipher-path.cpp
+++ b/src/game/cipher-path/cipher-path.cpp
@@ -2,6 +2,8 @@
 #include "game/cipher-path/cipher-path-states.hpp"
 
 void CipherPath::populateStateMap() {
+    seedRng(config.rngSeed);
+
     CipherPathIntro* intro = new CipherPathIntro(this);
     CipherPathShow* show = new CipherPathShow(this);
     CipherPathGameplay* gameplay = new CipherPathGameplay(this);
@@ -68,14 +70,6 @@ void CipherPath::populateStateMap() {
 void CipherPath::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void CipherPath::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }
 
 void CipherPath::generateCipher() {

--- a/src/game/exploit-sequencer/exploit-sequencer-intro.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer-intro.cpp
@@ -24,7 +24,7 @@ void ExploitSequencerIntro::onStateMounted(Device* PDN) {
 
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
 
     // Display title screen
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/exploit-sequencer/exploit-sequencer.cpp
+++ b/src/game/exploit-sequencer/exploit-sequencer.cpp
@@ -2,6 +2,8 @@
 #include "game/exploit-sequencer/exploit-sequencer-states.hpp"
 
 void ExploitSequencer::populateStateMap() {
+    seedRng(config.rngSeed);
+
     ExploitSequencerIntro* intro = new ExploitSequencerIntro(this);
     ExploitSequencerShow* show = new ExploitSequencerShow(this);
     ExploitSequencerGameplay* gameplay = new ExploitSequencerGameplay(this);
@@ -68,12 +70,4 @@ void ExploitSequencer::populateStateMap() {
 void ExploitSequencer::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void ExploitSequencer::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }

--- a/src/game/firewall-decrypt/decrypt-intro.cpp
+++ b/src/game/firewall-decrypt/decrypt-intro.cpp
@@ -23,7 +23,7 @@ void DecryptIntro::onStateMounted(Device* PDN) {
 
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
     game->setupRound();
 
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/firewall-decrypt/firewall-decrypt.cpp
+++ b/src/game/firewall-decrypt/firewall-decrypt.cpp
@@ -11,7 +11,7 @@ FirewallDecrypt::FirewallDecrypt(FirewallDecryptConfig config) :
 }
 
 void FirewallDecrypt::populateStateMap() {
-    seedRng();
+    seedRng(config.rngSeed);
 
     DecryptIntro* intro = new DecryptIntro(this);
     DecryptScan* scan = new DecryptScan(this);
@@ -64,14 +64,6 @@ void FirewallDecrypt::populateStateMap() {
 void FirewallDecrypt::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void FirewallDecrypt::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }
 
 std::string FirewallDecrypt::generateAddress() {

--- a/src/game/ghost-runner/ghost-runner-intro.cpp
+++ b/src/game/ghost-runner/ghost-runner-intro.cpp
@@ -26,7 +26,7 @@ void GhostRunnerIntro::onStateMounted(Device* PDN) {
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
 
     // Seed RNG for this run
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
 
     // Display title screen
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/ghost-runner/ghost-runner.cpp
+++ b/src/game/ghost-runner/ghost-runner.cpp
@@ -7,7 +7,7 @@
  * 0=Intro, 1=Show, 2=Gameplay, 3=Evaluate, 4=Win, 5=Lose
  */
 void GhostRunner::populateStateMap() {
-    seedRng();
+    seedRng(config.rngSeed);
 
     GhostRunnerIntro* intro = new GhostRunnerIntro(this);
     GhostRunnerShow* show = new GhostRunnerShow(this);
@@ -74,12 +74,4 @@ void GhostRunner::populateStateMap() {
 void GhostRunner::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void GhostRunner::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }

--- a/src/game/signal-echo/echo-intro.cpp
+++ b/src/game/signal-echo/echo-intro.cpp
@@ -21,7 +21,7 @@ void EchoIntro::onStateMounted(Device* PDN) {
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
 
     // Seed RNG and generate the first sequence
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
     game->getSession().currentSequence = game->generateSequence(
         game->getConfig().sequenceLength);
 

--- a/src/game/signal-echo/signal-echo.cpp
+++ b/src/game/signal-echo/signal-echo.cpp
@@ -9,7 +9,7 @@ SignalEcho::SignalEcho(SignalEchoConfig config) :
 }
 
 void SignalEcho::populateStateMap() {
-    seedRng();
+    seedRng(config.rngSeed);
 
     EchoIntro* intro = new EchoIntro(this);
     EchoShowSequence* showSequence = new EchoShowSequence(this);
@@ -70,14 +70,6 @@ void SignalEcho::populateStateMap() {
 void SignalEcho::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void SignalEcho::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }
 
 std::vector<bool> SignalEcho::generateSequence(int length) {

--- a/src/game/spike-vector/spike-vector-intro.cpp
+++ b/src/game/spike-vector/spike-vector-intro.cpp
@@ -24,7 +24,7 @@ void SpikeVectorIntro::onStateMounted(Device* PDN) {
 
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-    game->seedRng();
+    game->seedRng(game->getConfig().rngSeed);
 
     // Display title screen
     PDN->getDisplay()->invalidateScreen();

--- a/src/game/spike-vector/spike-vector.cpp
+++ b/src/game/spike-vector/spike-vector.cpp
@@ -2,6 +2,8 @@
 #include "game/spike-vector/spike-vector-states.hpp"
 
 void SpikeVector::populateStateMap() {
+    seedRng(config.rngSeed);
+
     SpikeVectorIntro* intro = new SpikeVectorIntro(this);
     SpikeVectorShow* show = new SpikeVectorShow(this);
     SpikeVectorGameplay* gameplay = new SpikeVectorGameplay(this);
@@ -68,12 +70,4 @@ void SpikeVector::populateStateMap() {
 void SpikeVector::resetGame() {
     MiniGame::resetGame();
     session.reset();
-}
-
-void SpikeVector::seedRng() {
-    if (config.rngSeed != 0) {
-        srand(static_cast<unsigned int>(config.rngSeed));
-    } else {
-        srand(static_cast<unsigned int>(0));
-    }
 }

--- a/test/test_cli/firewall-decrypt-tests.hpp
+++ b/test/test_cli/firewall-decrypt-tests.hpp
@@ -35,7 +35,7 @@ public:
 
 // Test: Generated addresses have correct format (XX:XX:XX:XX)
 void decryptAddressFormat(DecryptAddressTestSuite* suite) {
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     std::string addr = suite->game->generateAddress();
     // Format: "XX:XX:XX:XX" = 11 chars
     ASSERT_EQ(addr.length(), 11u);
@@ -46,17 +46,17 @@ void decryptAddressFormat(DecryptAddressTestSuite* suite) {
 
 // Test: Seeded RNG produces deterministic addresses
 void decryptAddressDeterministic(DecryptAddressTestSuite* suite) {
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     std::string addr1 = suite->game->generateAddress();
     // Re-seed with same seed
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     std::string addr2 = suite->game->generateAddress();
     ASSERT_EQ(addr1, addr2);
 }
 
 // Test: Decoy differs from target
 void decryptDecoyDiffers(DecryptAddressTestSuite* suite) {
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     std::string target = suite->game->generateAddress();
     std::string decoy = suite->game->generateDecoy(target, 0.0f);
     ASSERT_NE(target, decoy);
@@ -65,7 +65,7 @@ void decryptDecoyDiffers(DecryptAddressTestSuite* suite) {
 
 // Test: High similarity decoy shares some pairs with target
 void decryptDecoySimilarity(DecryptAddressTestSuite* suite) {
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     std::string target = suite->game->generateAddress();
     std::string decoy = suite->game->generateDecoy(target, 0.7f);
     ASSERT_NE(target, decoy);
@@ -76,7 +76,7 @@ void decryptDecoySimilarity(DecryptAddressTestSuite* suite) {
 
 // Test: setupRound populates candidates with target included
 void decryptSetupRoundContainsTarget(DecryptAddressTestSuite* suite) {
-    suite->game->seedRng();
+    suite->game->seedRng(suite->game->getConfig().rngSeed);
     suite->game->setupRound();
 
     auto& session = suite->game->getSession();

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -55,7 +55,7 @@ void echoSequenceGenerationLength(SignalEchoTestSuite* suite) {
     config.rngSeed = 42;
 
     SignalEcho tempGame(config);
-    tempGame.seedRng();
+    tempGame.seedRng(tempGame.getConfig().rngSeed);
     std::vector<bool> seq = tempGame.generateSequence(6);
     ASSERT_EQ(static_cast<int>(seq.size()), 6);
 
@@ -69,7 +69,7 @@ void echoSequenceGenerationMixed(SignalEchoTestSuite* suite) {
     config.rngSeed = 42;
 
     SignalEcho tempGame(config);
-    tempGame.seedRng();
+    tempGame.seedRng(tempGame.getConfig().rngSeed);
 
     std::vector<bool> seq = tempGame.generateSequence(100);
     int ups = 0, downs = 0;

--- a/test/test_cli/spike-vector-tests.hpp
+++ b/test/test_cli/spike-vector-tests.hpp
@@ -264,7 +264,7 @@ void spikeVectorMissedDodge(SpikeVectorTestSuite* suite) {
     // Use deterministic seed and short track
     config.rngSeed = 42;
     config.trackLength = 5;
-    suite->game_->seedRng();
+    suite->game_->seedRng(suite->game_->getConfig().rngSeed);
 
     // Skip to Show (index 1)
     suite->game_->skipToState(suite->device_.pdn, 1);


### PR DESCRIPTION
Partial fix for #167. Moves identical seedRng() from all 7 minigames to MiniGame base class. Removes ~42 lines of duplication.