### PR TITLE
Wave 12: Fix #173 — singleton state cleanup between CLI tests

### DIFF
--- a/include/cli/cli-http-server.hpp
+++ b/include/cli/cli-http-server.hpp
@@ -267,6 +267,19 @@ public:
         return lastProgressBody_;
     }
 
+    /**
+     * Reset the singleton instance to a clean state.
+     * Must be called between tests to prevent state pollution.
+     */
+    static void resetInstance() {
+        auto& instance = getInstance();
+        instance.playerConfigs_.clear();
+        instance.history_.clear();
+        instance.isOffline_ = false;
+        instance.responseDelayMs_ = 0;
+        instance.lastProgressBody_.clear();
+    }
+
 private:
     std::string lastProgressBody_;
 };

--- a/include/cli/cli-serial-broker.hpp
+++ b/include/cli/cli-serial-broker.hpp
@@ -220,7 +220,7 @@ public:
     size_t getConnectionCount() const {
         return connections_.size();
     }
-    
+
     /**
      * Get a string describing a connection for display.
      */
@@ -228,10 +228,20 @@ public:
         std::string jackAStr = (conn.jackA == JackType::OUTPUT_JACK) ? "out" : "in";
         std::string jackBStr = (conn.jackB == JackType::OUTPUT_JACK) ? "out" : "in";
         std::string typeStr = conn.sameRole ? "P-to-A" : "P-to-P";
-        return std::to_string(conn.deviceA) + "." + jackAStr + 
-               " <-> " + 
+        return std::to_string(conn.deviceA) + "." + jackAStr +
+               " <-> " +
                std::to_string(conn.deviceB) + "." + jackBStr +
                " (" + typeStr + ")";
+    }
+
+    /**
+     * Reset the singleton instance to a clean state.
+     * Must be called between tests to prevent state pollution.
+     */
+    static void resetInstance() {
+        auto& instance = getInstance();
+        instance.devices_.clear();
+        instance.connections_.clear();
     }
 
 private:

--- a/include/utils/simple-timer.hpp
+++ b/include/utils/simple-timer.hpp
@@ -16,6 +16,14 @@ public:
         return clock;
     }
 
+    /**
+     * Reset the static clock to nullptr.
+     * Must be called between tests to prevent state pollution.
+     */
+    static void resetClock() {
+        clock = nullptr;
+    }
+
     void updateTime(){
         if (clock == nullptr) {
             now = 0;

--- a/test/test_cli/boon-awarded-tests.hpp
+++ b/test/test_cli/boon-awarded-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/color-profiles.hpp"
 #include "game/progress-manager.hpp"
 #include "device/device-types.hpp"
@@ -18,12 +20,22 @@ using namespace cli;
 class BoonAwardedTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/breach-defense-tests.hpp
+++ b/test/test_cli/breach-defense-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/breach-defense/breach-defense.hpp"
 #include "game/breach-defense/breach-defense-states.hpp"
 #include "game/minigame.hpp"
@@ -21,6 +22,11 @@ using namespace cli;
 class BreachDefenseTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createGameDevice(0, "breach-defense");
         SimpleTimer::setPlatformClock(device_.clockDriver);
         game_ = static_cast<BreachDefense*>(device_.game);
@@ -28,6 +34,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/cipher-path-tests.hpp
+++ b/test/test_cli/cipher-path-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/cipher-path/cipher-path.hpp"
 #include "game/cipher-path/cipher-path-states.hpp"
 #include "game/minigame.hpp"
@@ -21,6 +22,11 @@ using namespace cli;
 class CipherPathTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createGameDevice(0, "cipher-path");
         SimpleTimer::setPlatformClock(device_.clockDriver);
         game_ = static_cast<CipherPath*>(device_.game);
@@ -28,6 +34,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/cli-fdn-tests.hpp
+++ b/test/test_cli/cli-fdn-tests.hpp
@@ -4,12 +4,19 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 
 using namespace cli;
 
 class CliFdnTestSuite : public testing::Test {
 protected:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         // Fresh test setup
     }
 };

--- a/test/test_cli/color-profile-tests.hpp
+++ b/test/test_cli/color-profile-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/color-profiles.hpp"
 #include "game/progress-manager.hpp"
 #include "game/minigame.hpp"
@@ -59,12 +61,22 @@ void colorProfileLookupNames(ColorProfileLookupTestSuite* /*suite*/) {
 class ColorProfilePromptTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/comprehensive-integration-tests.hpp
+++ b/test/test_cli/comprehensive-integration-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/signal-echo/signal-echo.hpp"
 #include "game/ghost-runner/ghost-runner.hpp"
 #include "game/spike-vector/spike-vector.hpp"
@@ -44,12 +45,22 @@ using namespace cli;
 class ComprehensiveIntegrationTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(player_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/device-extension-tests.hpp
+++ b/test/test_cli/device-extension-tests.hpp
@@ -4,18 +4,30 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 
 using namespace cli;
 
 class DeviceExtensionTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         // Fresh test setup
         device_ = DeviceFactory::createDevice(0, true);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     DeviceInstance device_;

--- a/test/test_cli/e2e-game-suite-tests.hpp
+++ b/test/test_cli/e2e-game-suite-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/ghost-runner/ghost-runner.hpp"
 #include "game/spike-vector/spike-vector.hpp"
 #include "game/cipher-path/cipher-path.hpp"
@@ -34,12 +35,22 @@ using namespace cli;
 class E2EGameSuiteTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(player_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/edge-case-tests.hpp
+++ b/test/test_cli/edge-case-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/player.hpp"
@@ -26,6 +27,11 @@ using namespace cli;
 class EdgeCaseTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
         player_ = device_.player;
@@ -34,6 +40,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/exploit-sequencer-tests.hpp
+++ b/test/test_cli/exploit-sequencer-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/exploit-sequencer/exploit-sequencer.hpp"
 #include "game/exploit-sequencer/exploit-sequencer-states.hpp"
 #include "game/minigame.hpp"
@@ -21,6 +22,11 @@ using namespace cli;
 class ExploitSequencerTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createGameDevice(0, "exploit-sequencer");
         SimpleTimer::setPlatformClock(device_.clockDriver);
         game_ = static_cast<ExploitSequencer*>(device_.game);
@@ -28,6 +34,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/fdn-integration-tests.hpp
+++ b/test/test_cli/fdn-integration-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/signal-echo/signal-echo.hpp"
 #include "game/signal-echo/signal-echo-states.hpp"
 #include "game/signal-echo/signal-echo-resources.hpp"
@@ -23,6 +24,11 @@ using namespace cli;
 class FdnIntegrationTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         // Device 0 = player (hunter), Device 1 = FDN NPC
         player_ = DeviceFactory::createDevice(0, true);
         fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
@@ -32,6 +38,11 @@ public:
     void TearDown() override {
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/firewall-decrypt-tests.hpp
+++ b/test/test_cli/firewall-decrypt-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-states.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
@@ -20,6 +22,11 @@ using namespace cli;
 class DecryptAddressTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         FirewallDecryptConfig config;
         config.rngSeed = 42;
         game = new FirewallDecrypt(config);
@@ -28,6 +35,11 @@ public:
 
     void TearDown() override {
         delete game;
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     FirewallDecrypt* game;

--- a/test/test_cli/ghost-runner-tests.hpp
+++ b/test/test_cli/ghost-runner-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/ghost-runner/ghost-runner.hpp"
 #include "game/ghost-runner/ghost-runner-states.hpp"
 #include "game/minigame.hpp"
@@ -21,6 +22,11 @@ using namespace cli;
 class GhostRunnerTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createGameDevice(0, "ghost-runner");
         SimpleTimer::setPlatformClock(device_.clockDriver);
         game_ = static_cast<GhostRunner*>(device_.game);
@@ -28,6 +34,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/hard-mode-reencounter-tests.hpp
+++ b/test/test_cli/hard-mode-reencounter-tests.hpp
@@ -34,6 +34,11 @@ using namespace cli;
 class HardModeReencounterTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         fdnSignalEcho_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
         fdnFirewall_ = DeviceFactory::createFdnDevice(2, GameType::FIREWALL_DECRYPT);
@@ -44,6 +49,11 @@ public:
         DeviceFactory::destroyDevice(fdnFirewall_);
         DeviceFactory::destroyDevice(fdnSignalEcho_);
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/konami-button-awarded-tests.hpp
+++ b/test/test_cli/konami-button-awarded-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/player.hpp"
 #include "game/progress-manager.hpp"
 #include "game/quickdraw-states/konami-button-awarded.hpp"
@@ -27,6 +29,11 @@ using namespace cli;
 class KonamiButtonAwardedTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(player_.clockDriver);
 
@@ -42,6 +49,11 @@ public:
     void TearDown() override {
         delete progressManager;
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     DeviceInstance player_;

--- a/test/test_cli/konami-code-tests.hpp
+++ b/test/test_cli/konami-code-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/konami-states/konami-code-entry.hpp"
@@ -23,6 +25,11 @@ using namespace cli;
 class KonamiCodeTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
         player_ = device_.player;
@@ -31,6 +38,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/konami-fdn-display-tests.hpp
+++ b/test/test_cli/konami-fdn-display-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/konami-states/konami-fdn-display.hpp"
 #include "game/player.hpp"
 #include "device/device-types.hpp"
@@ -17,6 +19,11 @@ using namespace cli;
 class KonamiFdnDisplayTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
         player_ = device_.player;
@@ -24,6 +31,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/konami-metagame-e2e-tests.hpp
+++ b/test/test_cli/konami-metagame-e2e-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/player.hpp"
 #include "game/konami-metagame/konami-metagame.hpp"
 #include "device/device-types.hpp"
@@ -25,6 +27,11 @@ using namespace cli;
 class KonamiMetaGameE2ETestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         fdn_ = DeviceFactory::createFdnDevice(1, GameType::GHOST_RUNNER);
 
@@ -38,6 +45,11 @@ public:
         SerialCableBroker::getInstance().disconnect(0, 1);
         DeviceFactory::destroyDevice(player_);
         DeviceFactory::destroyDevice(fdn_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/konami-progression-e2e-tests.hpp
+++ b/test/test_cli/konami-progression-e2e-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/player.hpp"
 #include "device/device-types.hpp"
 #include "utils/simple-timer.hpp"
@@ -25,12 +27,22 @@ using namespace cli;
 class KonamiProgressionE2ETestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(player_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     DeviceInstance player_;

--- a/test/test_cli/konami-puzzle-tests.hpp
+++ b/test/test_cli/konami-puzzle-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/player.hpp"
@@ -18,6 +20,11 @@ using namespace cli;
 class KonamiPuzzleTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);  // Create player device
         SimpleTimer::setPlatformClock(device_.clockDriver);
         player_ = device_.player;
@@ -26,6 +33,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/mastery-replay-tests.hpp
+++ b/test/test_cli/mastery-replay-tests.hpp
@@ -4,6 +4,8 @@
 
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/konami-states/mastery-replay.hpp"
@@ -19,6 +21,11 @@ using namespace cli;
 class MasteryReplayTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);  // Create player device
         SimpleTimer::setPlatformClock(device_.clockDriver);
         player_ = device_.player;
@@ -27,6 +34,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -12,7 +12,11 @@
 #include "device/drivers/native/native-light-strip-driver.hpp"
 #include "cli/cli-device.hpp"
 #include "cli/cli-commands.hpp"
+#include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw-states.hpp"
+
+using namespace cli;
 
 // ============================================
 // NATIVE SERIAL DRIVER TEST SUITE
@@ -21,11 +25,21 @@
 class NativeSerialDriverTestSuite : public testing::Test {
 public:  // Public for test function access
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         driver_ = new NativeSerialDriver("TestSerial");
     }
     
     void TearDown() override {
         delete driver_;
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
     
     NativeSerialDriver* driver_;

--- a/test/test_cli/negative-flow-tests.hpp
+++ b/test/test_cli/negative-flow-tests.hpp
@@ -33,6 +33,11 @@ using namespace cli;
 class NegativeFlowTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         hunter_ = DeviceFactory::createDevice(0, true);
         fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
         SimpleTimer::setPlatformClock(hunter_.clockDriver);
@@ -41,6 +46,11 @@ public:
     void TearDown() override {
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(hunter_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/progression-core-tests.hpp
+++ b/test/test_cli/progression-core-tests.hpp
@@ -25,6 +25,11 @@ using namespace cli;
 class DifficultyGatingTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
         SimpleTimer::setPlatformClock(player_.clockDriver);
@@ -33,6 +38,11 @@ public:
     void TearDown() override {
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/progression-e2e-tests.hpp
+++ b/test/test_cli/progression-e2e-tests.hpp
@@ -32,6 +32,11 @@ using namespace cli;
 class ProgressionE2ETestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         player_ = DeviceFactory::createDevice(0, true);
         fdn_ = DeviceFactory::createFdnDevice(1, GameType::SIGNAL_ECHO);
         SimpleTimer::setPlatformClock(player_.clockDriver);
@@ -40,6 +45,11 @@ public:
     void TearDown() override {
         DeviceFactory::destroyDevice(fdn_);
         DeviceFactory::destroyDevice(player_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {

--- a/test/test_cli/sequence-provider-tests.hpp
+++ b/test/test_cli/sequence-provider-tests.hpp
@@ -6,6 +6,7 @@
 #include "cli/cli-device.hpp"
 #include "game/sequence-provider.hpp"
 #include "device/drivers/native/native-http-client-driver.hpp"
+#include "cli/cli-serial-broker.hpp"
 #include "cli/cli-http-server.hpp"
 
 using namespace cli;
@@ -17,6 +18,11 @@ using namespace cli;
 class SequenceProviderTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         // Create a minimal device for HTTP client access
         device_ = DeviceFactory::createDevice(0, true);
         httpClient_ = dynamic_cast<NativeHttpClientDriver*>(device_.httpClientDriver);
@@ -29,6 +35,11 @@ public:
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     DeviceInstance device_;

--- a/test/test_cli/stress-tests.hpp
+++ b/test/test_cli/stress-tests.hpp
@@ -5,6 +5,7 @@
 #include <gtest/gtest.h>
 #include "cli/cli-device.hpp"
 #include "cli/cli-serial-broker.hpp"
+#include "cli/cli-http-server.hpp"
 #include "game/quickdraw.hpp"
 #include "game/quickdraw-states.hpp"
 #include "game/signal-echo/signal-echo.hpp"
@@ -24,12 +25,22 @@ using namespace cli;
 class StressTestSuite : public testing::Test {
 public:
     void SetUp() override {
+        // Reset all singleton state before each test to prevent pollution
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
+
         device_ = DeviceFactory::createDevice(0, true);
         SimpleTimer::setPlatformClock(device_.clockDriver);
     }
 
     void TearDown() override {
         DeviceFactory::destroyDevice(device_);
+
+        // Clean up singleton state after each test
+        SerialCableBroker::resetInstance();
+        MockHttpServer::resetInstance();
+        SimpleTimer::resetClock();
     }
 
     void tick(int n = 1) {


### PR DESCRIPTION
Fixes #173. Adds reset methods to SerialCableBroker, MockHttpServer, and SimpleTimer singletons. Calls resets in all 28 CLI test fixture SetUp/TearDown methods. All 126/126 CLI tests now pass together — no test-ordering sensitivity.