### PR TITLE
fix: FdnDetected empty message on game resume (#206)

### DIFF
--- a/src/game/quickdraw-states/fdn-detected-state.cpp
+++ b/src/game/quickdraw-states/fdn-detected-state.cpp
@@ -36,6 +36,14 @@ FdnDetected::~FdnDetected() {
 }
 
 void FdnDetected::onStateMounted(Device* PDN) {
+    // Guard: If we're resuming after launching a game, skip message parsing
+    // and transition directly to FdnComplete (onStateResumed already set the flag)
+    if (gameLaunched) {
+        LOG_I(TAG, "Resuming after game completion, transitioning to FdnComplete");
+        transitionToFdnCompleteState = true;
+        return;
+    }
+
     transitionToIdleState = false;
     transitionToFdnCompleteState = false;
     transitionToReencounterState = false;


### PR DESCRIPTION
Adds gameLaunched guard flag check in onStateMounted. On resume after game completion, skips empty message parse and transitions directly to FdnComplete.

## Problem
When FdnDetected state resumes after minigame completion, onStateMounted is called and tries to parse the pending challenge message. However, onStateDismounted has already cleared it, resulting in an empty message and a "Failed to parse" warning.

## Solution
Add a guard at the top of onStateMounted that checks if gameLaunched is true (set by onStateResumed). If so, skip message parsing and transition directly to FdnComplete.

## Changes
- `src/game/quickdraw-states/fdn-detected-state.cpp`: Add gameLaunched guard at start of onStateMounted

## Verification
- Build succeeds: native_cli environment
- 174 CLI tests pass (pre-existing failures unrelated)
- Logic verified: first mount continues normally, resume skips empty message parse

Closes #206.