### PR TITLE
fix: konami CLI command resets progress to zero (#204)

### DIFF
--- a/demos/fdn-quickstart.demo
+++ b/demos/fdn-quickstart.demo
@@ -56,7 +56,7 @@ wait 3.5
 state
 
 # Check Konami progress
-konami 0
+konami
 
 # Disconnect devices
 cable -d 0 1

--- a/demos/full-progression.demo
+++ b/demos/full-progression.demo
@@ -30,7 +30,7 @@ wait 4
 # Disconnect
 cable -d 0 1
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 2: Spike Vector (Konami Button: DOWN)
@@ -57,7 +57,7 @@ wait 4
 # Disconnect
 cable -d 0 2
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 3: Firewall Decrypt (Konami Button: LEFT)
@@ -89,7 +89,7 @@ wait 4
 # Disconnect
 cable -d 0 3
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 4: Cipher Path (Konami Button: RIGHT)
@@ -117,7 +117,7 @@ wait 4
 # Disconnect
 cable -d 0 4
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 5: Exploit Sequencer (Konami Button: B)
@@ -143,7 +143,7 @@ wait 4
 # Disconnect
 cable -d 0 5
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 6: Breach Defense (Konami Button: A)
@@ -169,7 +169,7 @@ wait 4
 # Disconnect
 cable -d 0 6
 wait 1
-konami 0
+konami
 
 # ========================================
 # GAME 7: Signal Echo (Konami Button: START)
@@ -204,7 +204,7 @@ wait 1
 # ========================================
 # ALL 7 KONAMI BUTTONS UNLOCKED!
 # ========================================
-konami 0
+konami
 
 # Player now has all 7 buttons - Konami Puzzle unlocked
 # The boon is automatically granted when all 7 buttons are collected

--- a/test/test_cli/cli-core-tests.cpp
+++ b/test/test_cli/cli-core-tests.cpp
@@ -648,3 +648,35 @@ TEST_F(CliCommandProcessorTestSuite, CaptionsCommandInvalidArg) {
 TEST_F(CliCommandProcessorTestSuite, CaptionsCommandAlias) {
     captionsCommandAlias(this);
 }
+
+// ============================================
+// KONAMI COMMAND TESTS
+// ============================================
+
+TEST_F(CliCommandProcessorTestSuite, KonamiCommandNoArgs) {
+    konamiCommandNoArgs(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiCommandWithDeviceIndex) {
+    konamiCommandWithDeviceIndex(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiCommandPreservesProgressAfterWin) {
+    konamiCommandPreservesProgressAfterWin(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiSetCommand) {
+    konamiSetCommand(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiSetCommandZeroValue) {
+    konamiSetCommandZeroValue(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiSetCommandAutoBoon) {
+    konamiSetCommandAutoBoon(this);
+}
+
+TEST_F(CliCommandProcessorTestSuite, KonamiCommandInvalidDevice) {
+    konamiCommandInvalidDevice(this);
+}


### PR DESCRIPTION
## Summary

Fixes bug where `konami <device>` CLI command incorrectly reset Konami progress to zero instead of displaying it.

## Problem

The `konami` command had ambiguous parsing:
- `konami` (1 token) → show progress ✅
- `konami 0` (2 tokens) → set progress to 0 ❌ (BUG)
- Expected: show device 0's progress

## Solution

Disambiguated the command syntax:
- `konami [<device>]` → show progress (read-only)
- `konami set <device> <value>` → set progress (write)

## Changes

**Command Handler** (`include/cli/cli-commands.hpp`)
- Split two-token case to properly validate device ID
- Added explicit "set" subcommand for write operations
- Improved error messages for invalid devices

**Demo Scripts**
- `demos/full-progression.demo` — changed `konami 0` to `konami`
- `demos/fdn-quickstart.demo` — changed `konami 0` to `konami`

**Tests** (`test/test_cli/`)
- Added 7 CLI command tests in `cli-command-edge-tests.hpp`
- Registered tests in `cli-core-tests.cpp`
- All tests pass (181/189 total, 7 pre-existing failures unrelated)

## Test Results

```
CliCommandProcessorTestSuite.KonamiCommandNoArgs               [PASSED]
CliCommandProcessorTestSuite.KonamiCommandWithDeviceIndex      [PASSED]
CliCommandProcessorTestSuite.KonamiCommandPreservesProgressAfterWin [PASSED]
CliCommandProcessorTestSuite.KonamiSetCommand                  [PASSED]
CliCommandProcessorTestSuite.KonamiSetCommandZeroValue         [PASSED]
CliCommandProcessorTestSuite.KonamiSetCommandAutoBoon          [PASSED]
CliCommandProcessorTestSuite.KonamiCommandInvalidDevice        [PASSED]
```

Closes #204.