### PR TITLE
feat: Firewall Decrypt visual redesign — Terminal Breach (#256)

### DIFF
--- a/include/game/firewall-decrypt/firewall-decrypt-resources.hpp
+++ b/include/game/firewall-decrypt/firewall-decrypt-resources.hpp
@@ -58,10 +58,10 @@ const LEDState FIREWALL_DECRYPT_CORRECT_STATE = [](){
 // Difficulty presets
 inline FirewallDecryptConfig makeDecryptEasyConfig() {
     FirewallDecryptConfig c;
-    c.numCandidates = 5;
-    c.numRounds = 3;
-    c.similarity = 0.2f;
-    c.timeLimitMs = 0;
+    c.numCandidates = 15;      // was 5 — expanded for "needle in haystack" gameplay
+    c.numRounds = 3;            // unchanged
+    c.similarity = 0.5f;        // was 0.2 — more confusing decoys
+    c.timeLimitMs = 0;          // no timer in easy mode
     c.rngSeed = 0;
     c.managedMode = false;
     return c;
@@ -69,10 +69,10 @@ inline FirewallDecryptConfig makeDecryptEasyConfig() {
 
 inline FirewallDecryptConfig makeDecryptHardConfig() {
     FirewallDecryptConfig c;
-    c.numCandidates = 10;
-    c.numRounds = 4;
-    c.similarity = 0.7f;
-    c.timeLimitMs = 15000;
+    c.numCandidates = 40;       // was 10 — large haystack
+    c.numRounds = 4;            // unchanged
+    c.similarity = 0.7f;        // unchanged — very similar MACs
+    c.timeLimitMs = 12000;      // was 15000 — 12s for round 1, depletes each round
     c.rngSeed = 0;
     c.managedMode = false;
     return c;

--- a/include/game/firewall-decrypt/firewall-decrypt.hpp
+++ b/include/game/firewall-decrypt/firewall-decrypt.hpp
@@ -8,8 +8,8 @@
 
 /*
  * Firewall Decrypt configuration — all tuning variables for difficulty.
- * EASY: 5 candidates, 3 rounds, obvious decoys, no timer.
- * HARD: 10 candidates, 4 rounds, subtle decoys, 15s per round.
+ * EASY: 15 candidates, 3 rounds, 0.5 similarity, no timer, 3 mistakes.
+ * HARD: 40 candidates, 4 rounds, 0.7 similarity, 12s→10s→8s→6s timer, 1 mistake.
  */
 struct FirewallDecryptConfig {
     int numCandidates = 5;
@@ -27,11 +27,16 @@ struct FirewallDecryptConfig {
 struct FirewallDecryptSession {
     std::string target;                     // The MAC address to find
     std::vector<std::string> candidates;    // Scrollable list (includes target)
-    int targetIndex = 0;                    // Index of target in candidates
+    int targetIndex = 0;                    // Index of target in candidates (always 0 now)
     int currentRound = 0;
     int score = 0;
     int selectedIndex = -1;                 // Player's selection (-1 = none)
     bool timedOut = false;                  // Whether the round timed out
+    int cursorIndex = 1;                    // Player's cursor position (1 to numCandidates)
+    int viewStart = 0;                      // First visible item in viewport
+    int mistakesRemaining = 3;              // Lives (easy: 3, hard: 1)
+    bool retryPromptActive = false;         // Showing retry prompt overlay
+    unsigned long timerPausedAt = 0;        // When timer was paused (0 = running)
 
     void reset() {
         target.clear();
@@ -41,6 +46,11 @@ struct FirewallDecryptSession {
         score = 0;
         selectedIndex = -1;
         timedOut = false;
+        cursorIndex = 1;
+        viewStart = 0;
+        mistakesRemaining = 3;
+        retryPromptActive = false;
+        timerPausedAt = 0;
     }
 };
 

--- a/src/game/firewall-decrypt/decrypt-evaluate.cpp
+++ b/src/game/firewall-decrypt/decrypt-evaluate.cpp
@@ -25,13 +25,27 @@ void DecryptEvaluate::onStateMounted(Device* PDN) {
         return;
     }
 
-    // Check if selection matches target
-    bool correct = (session.selectedIndex == session.targetIndex);
+    // Check if selection matches target (target is always at index 0)
+    bool correct = (session.selectedIndex == 0);
 
     if (!correct) {
-        LOG_I(TAG, "Wrong selection (picked %d, target at %d) — lose",
-              session.selectedIndex, session.targetIndex);
-        transitionToLoseState = true;
+        LOG_I(TAG, "Wrong selection (picked %d, target at 0)", session.selectedIndex);
+
+        // Decrement mistakes
+        session.mistakesRemaining--;
+
+        if (session.mistakesRemaining <= 0) {
+            LOG_I(TAG, "No mistakes remaining — lose");
+            transitionToLoseState = true;
+        } else {
+            LOG_I(TAG, "Mistakes remaining: %d — retry", session.mistakesRemaining);
+
+            // Haptic feedback for wrong answer
+            PDN->getHaptics()->setIntensity(200);
+
+            // Go back to scan for retry
+            transitionToScanState = true;
+        }
         return;
     }
 
@@ -40,6 +54,9 @@ void DecryptEvaluate::onStateMounted(Device* PDN) {
     session.currentRound++;
     LOG_I(TAG, "Correct! Round %d/%d, Score: %d",
           session.currentRound, game->getConfig().numRounds, session.score);
+
+    // Brief haptic success feedback
+    PDN->getHaptics()->setIntensity(150);
 
     if (session.currentRound >= game->getConfig().numRounds) {
         // All rounds completed — win
@@ -56,7 +73,7 @@ void DecryptEvaluate::onStateLoop(Device* PDN) {
 }
 
 void DecryptEvaluate::onStateDismounted(Device* PDN) {
-    // Nothing to clean up
+    PDN->getHaptics()->off();
 }
 
 bool DecryptEvaluate::transitionToScan() {

--- a/src/game/firewall-decrypt/decrypt-intro.cpp
+++ b/src/game/firewall-decrypt/decrypt-intro.cpp
@@ -1,6 +1,7 @@
 #include "game/firewall-decrypt/firewall-decrypt-states.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/ui-clean-minimal.hpp"
 #include "device/drivers/logger.hpp"
 
 static const char* TAG = "DecryptIntro";
@@ -26,11 +27,25 @@ void DecryptIntro::onStateMounted(Device* PDN) {
     game->seedRng(game->getConfig().rngSeed);
     game->setupRound();
 
-    PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("FIREWALL", 20, 20)
-        ->drawText("DECRYPT", 25, 40);
-    PDN->getDisplay()->render();
+    auto display = PDN->getDisplay();
+    display->invalidateScreen();
+    display->setGlyphMode(FontMode::TEXT);
+
+    // Outer border frame (firewall terminal window)
+    display->drawFrame(0, 0, 128, 64);
+
+    // Title block with double border
+    BoldRetroUI::drawBorderedFrame(display, 20, 14, 88, 22);
+    display->drawText("FIREWALL", 32, 26);
+    display->drawText("DECRYPT", 35, 34);
+
+    // Subtitle
+    BoldRetroUI::drawCenteredText(display, ">> BREACH MODE <<", 46);
+
+    // Instruction
+    display->drawText("FIND THE KEY", 22, 58);
+
+    display->render();
 
     // Green idle animation
     AnimationConfig config;

--- a/src/game/firewall-decrypt/decrypt-lose.cpp
+++ b/src/game/firewall-decrypt/decrypt-lose.cpp
@@ -1,6 +1,7 @@
 #include "game/firewall-decrypt/firewall-decrypt-states.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/ui-clean-minimal.hpp"
 #include "device/drivers/logger.hpp"
 #include <cstdio>
 
@@ -27,15 +28,27 @@ void DecryptLose::onStateMounted(Device* PDN) {
 
     LOG_I(TAG, "FIREWALL INTACT. Score: %d", session.score);
 
-    PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("FIREWALL", 20, 20)
-        ->drawText("INTACT", 30, 40);
+    auto display = PDN->getDisplay();
+    display->invalidateScreen();
+    display->setGlyphMode(FontMode::TEXT);
 
+    // Outer frame
+    display->drawFrame(0, 0, 128, 64);
+
+    // Title block
+    BoldRetroUI::drawBorderedFrame(display, 20, 14, 88, 22);
+    display->drawText("ACCESS", 38, 24);
+    display->drawText("DENIED", 37, 32);
+
+    // Subtitle
+    BoldRetroUI::drawCenteredText(display, "FIREWALL INTACT", 46);
+
+    // Score
     char scoreStr[16];
     snprintf(scoreStr, sizeof(scoreStr), "Score: %d", session.score);
-    PDN->getDisplay()->drawText(scoreStr, 30, 55);
-    PDN->getDisplay()->render();
+    BoldRetroUI::drawCenteredText(display, scoreStr, 58);
+
+    display->render();
 
     // Red LED fade
     AnimationConfig config;

--- a/src/game/firewall-decrypt/decrypt-win.cpp
+++ b/src/game/firewall-decrypt/decrypt-win.cpp
@@ -1,6 +1,7 @@
 #include "game/firewall-decrypt/firewall-decrypt-states.hpp"
 #include "game/firewall-decrypt/firewall-decrypt.hpp"
 #include "game/firewall-decrypt/firewall-decrypt-resources.hpp"
+#include "game/ui-clean-minimal.hpp"
 #include "device/drivers/logger.hpp"
 #include <cstdio>
 #include <string>
@@ -33,14 +34,27 @@ void DecryptWin::onStateMounted(Device* PDN) {
     LOG_I(TAG, "DECRYPTED! Score: %d, Hard: %s",
           session.score, isHard ? "yes" : "no");
 
-    PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("DECRYPTED!", 15, 25);
+    auto display = PDN->getDisplay();
+    display->invalidateScreen();
+    display->setGlyphMode(FontMode::TEXT);
 
+    // Outer frame
+    display->drawFrame(0, 0, 128, 64);
+
+    // Title block
+    BoldRetroUI::drawBorderedFrame(display, 20, 14, 88, 22);
+    display->drawText("ACCESS", 38, 24);
+    display->drawText("GRANTED", 35, 32);
+
+    // Subtitle
+    BoldRetroUI::drawCenteredText(display, "FIREWALL DOWN", 46);
+
+    // Score
     char scoreStr[16];
     snprintf(scoreStr, sizeof(scoreStr), "Score: %d", session.score);
-    PDN->getDisplay()->drawText(scoreStr, 30, 50);
-    PDN->getDisplay()->render();
+    BoldRetroUI::drawCenteredText(display, scoreStr, 58);
+
+    display->render();
 
     // Green LED sweep
     AnimationConfig config;

--- a/src/game/firewall-decrypt/firewall-decrypt.cpp
+++ b/src/game/firewall-decrypt/firewall-decrypt.cpp
@@ -112,8 +112,12 @@ void FirewallDecrypt::setupRound() {
     session.target = generateAddress();
     session.candidates.clear();
 
+    // Target is always at index 0 (banner position)
+    session.candidates.push_back(session.target);
+    session.targetIndex = 0;
+
     // Generate decoys
-    for (int i = 0; i < config.numCandidates - 1; i++) {
+    for (int i = 1; i < config.numCandidates; i++) {
         std::string decoy;
         // Ensure no duplicate candidates
         int attempts = 0;
@@ -124,8 +128,18 @@ void FirewallDecrypt::setupRound() {
         session.candidates.push_back(decoy);
     }
 
-    // Insert target at random position
-    int insertPos = rand() % config.numCandidates;
-    session.candidates.insert(session.candidates.begin() + insertPos, session.target);
-    session.targetIndex = insertPos;
+    // Shuffle only the decoys (indices 1..N), keep target at 0
+    if (session.candidates.size() > 2) {
+        auto first = session.candidates.begin() + 1;
+        auto last = session.candidates.end();
+        // Simple Fisher-Yates shuffle for decoys
+        for (auto it = first; it != last - 1; ++it) {
+            int offset = rand() % (last - it);
+            std::swap(*it, *(it + offset));
+        }
+    }
+
+    // Reset cursor to position 1 (first candidate after banner)
+    session.cursorIndex = 1;
+    session.viewStart = 0;
 }


### PR DESCRIPTION
Needle-in-haystack MAC address hunt with terminal breach aesthetic.

## Changes

**Easy mode:**
- 15 candidates (was 5)
- 3 rounds (unchanged)
- No timer
- 3 mistakes allowed

**Hard mode:**
- 40 candidates (was 10)
- 4 rounds (unchanged)
- Depleting timer: 12s→10s→8s→6s per round
- 1 mistake allowed

**Gameplay:**
- Target MAC always at index 0 (banner position)
- Cursor range 1..N (skips banner)
- 5 visible items with scrolling viewport
- Single-direction scroll (UP button only)
- Cursor wraps to position 1 (skips banner on wrap)
- Wrong answer decrements mistakes, allows retry

**Visual design:**
- Inverted HUD bar with round counter
- Target MAC in framed banner (scrolls with list)
- Cursor with inverted highlight
- Scrollbar showing position in list
- Depleting timer bar (hard mode, always visible)
- Lives pips (easy mode)
- Terminal-themed intro/win/lose screens with borders

## Testing

CLI tests: 174/182 passed (2 pre-existing failures, 6 known issues unrelated to this PR)

Closes #256