### PR TITLE
feat: Cipher Path visual redesign — wire rotation puzzle (#242)

### DIFF
--- a/include/game/cipher-path/cipher-path-resources.hpp
+++ b/include/game/cipher-path/cipher-path-resources.hpp
@@ -4,8 +4,58 @@
 #include <cstdint>
 
 /*
- * Cipher Path LED palettes — green/emerald "pathfinding" theme.
+ * Cipher Path rendering constants and LED palettes.
+ * Wire routing puzzle with real-time electricity flow visualization.
  */
+
+// Grid layout constants
+constexpr int CELL_PITCH = 9;           // pixels between cell origins (8x8 inner + 1px border)
+constexpr int CELL_INNER = 8;           // inner cell rendering area
+constexpr int WIRE_WIDTH = 2;           // path wire thickness (2px bold)
+constexpr int NOISE_WIDTH = 1;          // noise wire thickness (1px thin)
+
+// Tile type enumeration
+enum TileType {
+    TILE_EMPTY = 0,      // No wire segment
+    TILE_STRAIGHT = 1,   // Line (2 opposite edges)
+    TILE_ELBOW = 2,      // 90° bend (2 adjacent edges)
+    TILE_T_JUNCTION = 3, // T-shape (3 edges)
+    TILE_CROSS = 4,      // + shape (all 4 edges)
+    TILE_ENDPOINT = 5    // Terminal (1 edge)
+};
+
+// Direction bits for wire connections (can be OR'd together)
+constexpr int DIR_UP    = 1 << 0;  // 0x01
+constexpr int DIR_RIGHT = 1 << 1;  // 0x02
+constexpr int DIR_DOWN  = 1 << 2;  // 0x04
+constexpr int DIR_LEFT  = 1 << 3;  // 0x08
+
+// Tile rotation to connection mapping (rotation × 90°)
+// Returns DIR_* bitmask for each tile type at each rotation
+inline int getTileConnections(int tileType, int rotation) {
+    // Base connections for rotation 0
+    int base = 0;
+    switch (tileType) {
+        case TILE_STRAIGHT:   base = DIR_LEFT | DIR_RIGHT; break;   // Horizontal line
+        case TILE_ELBOW:      base = DIR_UP | DIR_RIGHT; break;     // Up-right bend
+        case TILE_T_JUNCTION: base = DIR_UP | DIR_RIGHT | DIR_DOWN; break;  // Missing left
+        case TILE_CROSS:      base = DIR_UP | DIR_RIGHT | DIR_DOWN | DIR_LEFT; break;
+        case TILE_ENDPOINT:   base = DIR_RIGHT; break;              // Pointing right
+        default: return 0;
+    }
+
+    // Rotate connections clockwise by rotation steps
+    int result = 0;
+    for (int i = 0; i < 4; i++) {
+        if (base & (1 << i)) {
+            int newDir = (i + rotation) % 4;
+            result |= (1 << newDir);
+        }
+    }
+    return result;
+}
+
+// LED palettes — emerald "circuit" theme
 
 // Primary palette (4 colors)
 const LEDColor cipherPathColors[4] = {
@@ -35,7 +85,7 @@ const LEDState CIPHER_PATH_IDLE_STATE = [](){
     return state;
 }();
 
-// Gameplay state — emerald chase
+// Gameplay state — emerald electrical chase
 const LEDState CIPHER_PATH_GAMEPLAY_STATE = [](){
     LEDState state;
     for (int i = 0; i < 9; i++) {
@@ -48,7 +98,7 @@ const LEDState CIPHER_PATH_GAMEPLAY_STATE = [](){
     return state;
 }();
 
-// Win state — bright emerald sweep
+// Win state — bright emerald power wave
 const LEDState CIPHER_PATH_WIN_STATE = [](){
     LEDState state;
     for (int i = 0; i < 9; i++) {
@@ -59,33 +109,13 @@ const LEDState CIPHER_PATH_WIN_STATE = [](){
     return state;
 }();
 
-// Lose state — red fade
+// Lose state — red circuit break surge
 const LEDState CIPHER_PATH_LOSE_STATE = [](){
     LEDState state;
     for (int i = 0; i < 9; i++) {
         uint8_t brightness = static_cast<uint8_t>(255 - (i * 25));
         state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
         state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), brightness);
-    }
-    return state;
-}();
-
-// Correct move flash — green
-const LEDState CIPHER_PATH_CORRECT_STATE = [](){
-    LEDState state;
-    for (int i = 0; i < 9; i++) {
-        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
-        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(0, 255, 0), 255);
-    }
-    return state;
-}();
-
-// Wrong move flash — red
-const LEDState CIPHER_PATH_WRONG_STATE = [](){
-    LEDState state;
-    for (int i = 0; i < 9; i++) {
-        state.leftLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
-        state.rightLights[i] = LEDState::SingleLEDState(LEDColor(255, 0, 0), 255);
     }
     return state;
 }();

--- a/include/game/cipher-path/cipher-path-states.hpp
+++ b/include/game/cipher-path/cipher-path-states.hpp
@@ -18,7 +18,8 @@ enum CipherPathStateId {
 };
 
 /*
- * CipherPathIntro — Title screen. Shows "CIPHER PATH" and subtitle.
+ * CipherPathIntro — Title screen. Shows "CIPHER PATH" and "Route the signal."
+ * Brief circuit animation (random wires flash on/off).
  * Resets session, seeds RNG. Transitions to CipherPathShow.
  */
 class CipherPathIntro : public State {
@@ -34,13 +35,15 @@ public:
 private:
     CipherPath* game;
     SimpleTimer introTimer;
+    SimpleTimer animTimer;        // For flashing circuit animation
     static constexpr int INTRO_DURATION_MS = 2000;
     bool transitionToShowState = false;
 };
 
 /*
- * CipherPathShow — Round setup screen. Displays "Round X of Y".
- * Generates the cipher for this round. Resets position and moves.
+ * CipherPathShow — Round setup screen. Displays grid with all tiles in scrambled orientations.
+ * Round pips shown for hard mode. Brief preview (~2s) for the player to plan.
+ * Generates the path and noise tiles. Resets flow and cursor state.
  * Transitions to CipherPathGameplay after SHOW_DURATION_MS.
  */
 class CipherPathShow : public State {
@@ -56,14 +59,22 @@ public:
 private:
     CipherPath* game;
     SimpleTimer showTimer;
-    static constexpr int SHOW_DURATION_MS = 1500;
+    static constexpr int SHOW_DURATION_MS = 2000;
     bool transitionToGameplayState = false;
+
+    void renderShowScreen(Device* PDN);
+    void renderGrid(Device* PDN, int gridX, int gridY);
+    void renderTile(Device* PDN, int cellX, int cellY, int cellIndex);
+    void renderWireTile(Device* PDN, int x, int y, int tileType, int rotation, int wireWidth);
 };
 
 /*
- * CipherPathGameplay — Core gameplay. Player presses UP/DOWN each step.
- * Correct direction advances position, wrong wastes a move.
- * Transitions to CipherPathEvaluate when exit reached or budget exhausted.
+ * CipherPathGameplay — Core gameplay. Player rotates wire tiles to complete circuit.
+ * UP (primary) = navigate to next tile
+ * DOWN (secondary) = rotate current tile 90° clockwise
+ * Electricity flows pixel-by-pixel from input terminal. If it reaches a disconnection,
+ * the puzzle fails (circuit break). If it reaches the output terminal, the round wins.
+ * Transitions to CipherPathEvaluate when circuit completes or breaks.
  */
 class CipherPathGameplay : public State {
 public:
@@ -75,16 +86,27 @@ public:
     void onStateDismounted(Device* PDN) override;
     bool transitionToEvaluate();
 
-    // Called from button callbacks to signal end condition
+    // Called from button callbacks
     void setNeedsEvaluation() { needsEvaluation = true; }
+    void setCircuitBreak() { circuitBroken = true; }
 
 private:
     CipherPath* game;
     bool transitionToEvaluateState = false;
     bool needsEvaluation = false;
-    bool displayIsDirty = false;
+    bool circuitBroken = false;
+    bool displayIsDirty = true;
+
+    SimpleTimer flowTimer;           // Controls electricity advancement speed
+    SimpleTimer cursorBlinkTimer;    // Cursor blink animation (~300ms toggle)
+    bool cursorVisible = true;
 
     void renderGameplayScreen(Device* PDN);
+    void renderGrid(Device* PDN, int gridX, int gridY);
+    void renderTile(Device* PDN, int cellX, int cellY, int cellIndex, bool isCursor, bool isEnergized, int flowPixel);
+    void renderWireTile(Device* PDN, int x, int y, int tileType, int rotation, int wireWidth, bool invert);
+    void advanceFlow(Device* PDN);  // Move electricity forward one pixel
+    bool checkConnection(int fromIndex, int toIndex);  // Validate wire connection
 };
 
 /*
@@ -113,8 +135,9 @@ private:
 };
 
 /*
- * CipherPathWin — Victory screen. Shows "PATH DECODED".
- * Sets outcome to WON. In standalone mode, transitions back to Intro.
+ * CipherPathWin — Victory screen. Shows "CIRCUIT ROUTED".
+ * Power wave cascade animation. Sets outcome to WON.
+ * In standalone mode, transitions back to Intro.
  * In managed mode, calls Device::returnToPreviousApp().
  */
 class CipherPathWin : public State {
@@ -136,7 +159,8 @@ private:
 };
 
 /*
- * CipherPathLose — Defeat screen. Shows "PATH LOST".
+ * CipherPathLose — Defeat screen. Shows "CIRCUIT BREAK".
+ * Spark animation at disconnection point + full haptic surge (255) + screen flash.
  * Sets outcome to LOST. In standalone mode, transitions back to Intro.
  * In managed mode, calls Device::returnToPreviousApp().
  */
@@ -154,6 +178,9 @@ public:
 private:
     CipherPath* game;
     SimpleTimer loseTimer;
+    SimpleTimer sparkTimer;       // Spark animation timing
+    int sparkFlashCount = 0;      // Track spark flash cycles
     static constexpr int LOSE_DISPLAY_MS = 3000;
+    static constexpr int SPARK_FLASH_MS = 130;  // ~130ms per flash
     bool transitionToIntroState = false;
 };

--- a/include/game/difficulty-helpers.hpp
+++ b/include/game/difficulty-helpers.hpp
@@ -116,18 +116,21 @@ inline FirewallDecryptConfig makeScaledFirewallDecryptConfig(float scale, bool m
 }
 
 /*
- * Cipher Path scaled config
- * Easy: size=6, budget=12, rounds=2
- * Hard: size=10, budget=14, rounds=4
+ * Cipher Path scaled config (wire routing puzzle)
+ * Easy: 5x4 grid, 1 round, 200ms flow, 30% noise
+ * Hard: 7x5 grid, 3 rounds, 80ms flow, 40% noise
  */
 inline CipherPathConfig makeScaledCipherPathConfig(float scale, bool managedMode = false) {
     const auto& easy = CIPHER_PATH_EASY;
     const auto& hard = CIPHER_PATH_HARD;
 
     CipherPathConfig config;
-    config.gridSize = lerp(easy.gridSize, hard.gridSize, scale);
-    config.moveBudget = lerp(easy.moveBudget, hard.moveBudget, scale);
+    config.cols = lerp(easy.cols, hard.cols, scale);
+    config.rows = lerp(easy.rows, hard.rows, scale);
     config.rounds = lerp(easy.rounds, hard.rounds, scale);
+    config.flowSpeedMs = lerp(easy.flowSpeedMs, hard.flowSpeedMs, scale);
+    config.flowSpeedDecayMs = lerp(easy.flowSpeedDecayMs, hard.flowSpeedDecayMs, scale);
+    config.noisePercent = lerp(easy.noisePercent, hard.noisePercent, scale);
     config.rngSeed = 0;
     config.managedMode = managedMode;
 

--- a/src/game/cipher-path/cipher-path-evaluate.cpp
+++ b/src/game/cipher-path/cipher-path-evaluate.cpp
@@ -20,13 +20,15 @@ void CipherPathEvaluate::onStateMounted(Device* PDN) {
     auto& session = game->getSession();
     auto& config = game->getConfig();
 
-    // Check if player reached exit (round complete)
-    if (session.playerPosition >= config.gridSize - 1) {
+    // Check if electricity reached the output terminal (round complete)
+    // flowActive == false means flow stopped (either win or circuit break)
+    // flowTileIndex >= pathLength means we completed the circuit
+    if (!session.flowActive && session.flowTileIndex >= session.pathLength) {
         // Round complete — award score
         session.score += 100;
         session.currentRound++;
 
-        LOG_I(TAG, "Round complete. Score: %d, Round: %d/%d",
+        LOG_I(TAG, "Circuit routed. Score: %d, Round: %d/%d",
               session.score, session.currentRound, config.rounds);
 
         // Check if all rounds completed
@@ -37,9 +39,8 @@ void CipherPathEvaluate::onStateMounted(Device* PDN) {
             transitionToShowState = true;
         }
     } else {
-        // Budget exhausted without reaching exit — lose
-        LOG_I(TAG, "Budget exhausted at position %d/%d",
-              session.playerPosition, config.gridSize - 1);
+        // Circuit break — flow stopped before reaching output
+        LOG_I(TAG, "Circuit break at tile %d/%d", session.flowTileIndex, session.pathLength);
         transitionToLoseState = true;
     }
 }

--- a/src/game/cipher-path/cipher-path-gameplay.cpp
+++ b/src/game/cipher-path/cipher-path-gameplay.cpp
@@ -17,66 +17,75 @@ CipherPathGameplay::~CipherPathGameplay() {
 void CipherPathGameplay::onStateMounted(Device* PDN) {
     transitionToEvaluateState = false;
     needsEvaluation = false;
+    circuitBroken = false;
     displayIsDirty = true;
+    cursorVisible = true;
 
     LOG_I(TAG, "Gameplay started");
 
-    // LED chase animation during gameplay
-    AnimationConfig config;
-    config.type = AnimationType::VERTICAL_CHASE;
-    config.speed = 20;
-    config.curve = EaseCurve::LINEAR;
-    config.initialState = CIPHER_PATH_GAMEPLAY_STATE;
-    config.loopDelayMs = 0;
-    config.loop = true;
-    PDN->getLightManager()->startAnimation(config);
+    auto& config = game->getConfig();
+    auto& session = game->getSession();
 
-    // Set up button callbacks — UP (primary) and DOWN (secondary)
+    // Start flow active
+    session.flowActive = true;
+    session.flowTileIndex = 0;
+    session.flowPixelInTile = 0;
+
+    // Start LED animation — emerald electrical chase
+    AnimationConfig ledConfig;
+    ledConfig.type = AnimationType::VERTICAL_CHASE;
+    ledConfig.speed = 20;
+    ledConfig.curve = EaseCurve::LINEAR;
+    ledConfig.initialState = CIPHER_PATH_GAMEPLAY_STATE;
+    ledConfig.loopDelayMs = 0;
+    ledConfig.loop = true;
+    PDN->getLightManager()->startAnimation(ledConfig);
+
+    // Set up flow timer based on difficulty
+    int flowSpeed = config.flowSpeedMs - (session.currentRound * config.flowSpeedDecayMs);
+    flowTimer.setTimer(flowSpeed);
+
+    // Set up cursor blink timer
+    cursorBlinkTimer.setTimer(300);
+
+    // Button callbacks: UP = navigate to next tile, DOWN = rotate current tile
     parameterizedCallbackFunction upCallback = [](void* ctx) {
         auto* state = static_cast<CipherPathGameplay*>(ctx);
-        auto* gm = state->game;
-        auto& sess = gm->getSession();
-        auto& cfg = gm->getConfig();
+        auto& sess = state->game->getSession();
 
-        // Player chose UP
-        if (sess.cipher[sess.playerPosition] == 0) {
-            // Correct — advance position
-            sess.playerPosition++;
-            sess.lastMoveCorrect = true;
-        } else {
-            // Wrong — waste a move
-            sess.lastMoveCorrect = false;
+        // Move cursor to next path tile
+        sess.cursorPathIndex++;
+        if (sess.cursorPathIndex >= sess.pathLength) {
+            sess.cursorPathIndex = 0;  // Wrap to first tile
         }
-        sess.movesUsed++;
 
-        // Check end conditions
-        if (sess.playerPosition >= cfg.gridSize - 1 || sess.movesUsed >= cfg.moveBudget) {
-            state->setNeedsEvaluation();
-        }
+        // Haptic feedback
         state->displayIsDirty = true;
     };
 
     parameterizedCallbackFunction downCallback = [](void* ctx) {
         auto* state = static_cast<CipherPathGameplay*>(ctx);
-        auto* gm = state->game;
-        auto& sess = gm->getSession();
-        auto& cfg = gm->getConfig();
+        auto& sess = state->game->getSession();
 
-        // Player chose DOWN
-        if (sess.cipher[sess.playerPosition] == 1) {
-            // Correct — advance position
-            sess.playerPosition++;
-            sess.lastMoveCorrect = true;
-        } else {
-            // Wrong — waste a move
-            sess.lastMoveCorrect = false;
+        // Find current cursor cell index
+        int cursorCellIndex = -1;
+        for (int i = 0; i < 35; i++) {
+            if (sess.pathOrder[i] == sess.cursorPathIndex) {
+                cursorCellIndex = i;
+                break;
+            }
         }
-        sess.movesUsed++;
 
-        // Check end conditions
-        if (sess.playerPosition >= cfg.gridSize - 1 || sess.movesUsed >= cfg.moveBudget) {
-            state->setNeedsEvaluation();
+        if (cursorCellIndex == -1) return;  // Safety check
+
+        // Don't rotate terminals (input/output are fixed)
+        if (sess.cursorPathIndex == 0 || sess.cursorPathIndex == sess.pathLength - 1) {
+            return;
         }
+
+        // Rotate tile 90° clockwise
+        sess.tileRotation[cursorCellIndex] = (sess.tileRotation[cursorCellIndex] + 1) % 4;
+
         state->displayIsDirty = true;
     };
 
@@ -87,11 +96,34 @@ void CipherPathGameplay::onStateMounted(Device* PDN) {
 }
 
 void CipherPathGameplay::onStateLoop(Device* PDN) {
+    auto& session = game->getSession();
+
+    // Check for evaluation transition (win/lose)
     if (needsEvaluation) {
         transitionToEvaluateState = true;
         return;
     }
 
+    // Advance electricity flow
+    if (session.flowActive && flowTimer.expired()) {
+        advanceFlow(PDN);
+
+        // Reset flow timer
+        auto& config = game->getConfig();
+        int flowSpeed = config.flowSpeedMs - (session.currentRound * config.flowSpeedDecayMs);
+        flowTimer.setTimer(flowSpeed);
+
+        displayIsDirty = true;
+    }
+
+    // Cursor blink animation
+    if (cursorBlinkTimer.expired()) {
+        cursorVisible = !cursorVisible;
+        cursorBlinkTimer.setTimer(300);
+        displayIsDirty = true;
+    }
+
+    // Redraw if dirty
     if (displayIsDirty) {
         renderGameplayScreen(PDN);
         displayIsDirty = false;
@@ -101,34 +133,288 @@ void CipherPathGameplay::onStateLoop(Device* PDN) {
 void CipherPathGameplay::onStateDismounted(Device* PDN) {
     transitionToEvaluateState = false;
     needsEvaluation = false;
+    circuitBroken = false;
     displayIsDirty = false;
+    flowTimer.invalidate();
+    cursorBlinkTimer.invalidate();
     PDN->getPrimaryButton()->removeButtonCallbacks();
     PDN->getSecondaryButton()->removeButtonCallbacks();
+    PDN->getHaptics()->off();
 }
 
 bool CipherPathGameplay::transitionToEvaluate() {
     return transitionToEvaluateState;
 }
 
-void CipherPathGameplay::renderGameplayScreen(Device* PDN) {
+/*
+ * Advance electricity flow by one pixel.
+ * Checks for circuit completion (reached output terminal) or circuit break (disconnection).
+ */
+void CipherPathGameplay::advanceFlow(Device* PDN) {
+    auto& session = game->getSession();
+
+    session.flowPixelInTile++;
+
+    // Check if flow has reached the exit edge of the current tile (~9 pixels per tile)
+    if (session.flowPixelInTile >= 9) {
+        // Move to next tile on path
+        int nextTileIndex = session.flowTileIndex + 1;
+
+        // Check if we've reached the output terminal (last tile on path)
+        if (nextTileIndex >= session.pathLength) {
+            // CIRCUIT COMPLETE — WIN
+            session.flowActive = false;
+            setNeedsEvaluation();
+            return;
+        }
+
+        // Find current and next cell indices
+        int currentCellIndex = -1;
+        int nextCellIndex = -1;
+        for (int i = 0; i < 35; i++) {
+            if (session.pathOrder[i] == session.flowTileIndex) currentCellIndex = i;
+            if (session.pathOrder[i] == nextTileIndex) nextCellIndex = i;
+        }
+
+        // Check connection between current tile and next tile
+        if (!checkConnection(currentCellIndex, nextCellIndex)) {
+            // CIRCUIT BREAK — LOSE
+            session.flowActive = false;
+            setCircuitBreak();
+            setNeedsEvaluation();
+            return;
+        }
+
+        // Advance to next tile
+        session.flowTileIndex = nextTileIndex;
+        session.flowPixelInTile = 0;
+    }
+}
+
+/*
+ * Check if two tiles are properly connected (wire segments align at shared edge).
+ * Returns true if electricity can flow from fromIndex to toIndex.
+ */
+bool CipherPathGameplay::checkConnection(int fromIndex, int toIndex) {
     auto& session = game->getSession();
     auto& config = game->getConfig();
 
-    std::string posText = "Pos: " + std::to_string(session.playerPosition)
-                        + "/" + std::to_string(config.gridSize - 1);
-    std::string moveText = "Moves: " + std::to_string(session.movesUsed)
-                         + "/" + std::to_string(config.moveBudget);
+    int fromX = fromIndex % config.cols;
+    int fromY = fromIndex / config.cols;
+    int toX = toIndex % config.cols;
+    int toY = toIndex / config.cols;
 
-    PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText(posText.c_str(), 10, 20)
-        ->drawText(moveText.c_str(), 10, 40);
+    // Determine which edge of fromIndex connects to which edge of toIndex
+    int fromExitDir = -1;
+    int toEntryDir = -1;
 
-    // Show feedback for last move
-    if (session.movesUsed > 0) {
-        const char* feedback = session.lastMoveCorrect ? ">> CORRECT" : ">> WRONG";
-        PDN->getDisplay()->drawText(feedback, 10, 58);
+    if (toX > fromX) {
+        // toIndex is to the right of fromIndex
+        fromExitDir = 1;  // DIR_RIGHT (exit right edge of fromIndex)
+        toEntryDir = 3;   // DIR_LEFT (enter left edge of toIndex)
+    } else if (toX < fromX) {
+        // toIndex is to the left of fromIndex
+        fromExitDir = 3;  // DIR_LEFT
+        toEntryDir = 1;   // DIR_RIGHT
+    } else if (toY > fromY) {
+        // toIndex is below fromIndex
+        fromExitDir = 2;  // DIR_DOWN
+        toEntryDir = 0;   // DIR_UP
+    } else {
+        // toIndex is above fromIndex
+        fromExitDir = 0;  // DIR_UP
+        toEntryDir = 2;   // DIR_DOWN
     }
 
+    // Get connection bitmasks for both tiles
+    int fromType = session.tileType[fromIndex];
+    int fromRotation = session.tileRotation[fromIndex];
+    int fromConnections = getTileConnections(fromType, fromRotation);
+
+    int toType = session.tileType[toIndex];
+    int toRotation = session.tileRotation[toIndex];
+    int toConnections = getTileConnections(toType, toRotation);
+
+    // Check if fromIndex has an exit on the correct edge
+    if (!(fromConnections & (1 << fromExitDir))) {
+        return false;
+    }
+
+    // Check if toIndex has an entry on the correct edge
+    if (!(toConnections & (1 << toEntryDir))) {
+        return false;
+    }
+
+    return true;
+}
+
+/*
+ * Render the gameplay screen: grid with energized tiles, flow front, cursor highlight, HUD.
+ */
+void CipherPathGameplay::renderGameplayScreen(Device* PDN) {
+    auto& config = game->getConfig();
+    auto& session = game->getSession();
+
+    PDN->getDisplay()->invalidateScreen();
+
+    // Calculate grid position
+    int gridWidth = config.cols * CELL_PITCH + 1;
+    int gridHeight = config.rows * CELL_PITCH + 1;
+    int gridX = 4;
+    int gridY = (64 - gridHeight) / 2;
+
+    // Draw top bar: round pips + flow progress bar
+    if (config.rounds > 1) {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+        int pipX = 4;
+        for (int i = 0; i < config.rounds; i++) {
+            const char* pip = (i < session.currentRound) ? "\x07" : (i == session.currentRound) ? "\x07" : "\x08";
+            PDN->getDisplay()->drawText(pip, pipX, 3);
+            pipX += 8;
+        }
+    }
+
+    // Flow progress bar (top-right corner)
+    int barWidth = 40;
+    int barHeight = 4;
+    int barX = 128 - barWidth - 4;
+    int barY = 2;
+    int fillWidth = (session.flowTileIndex * barWidth) / (session.pathLength > 0 ? session.pathLength : 1);
+    PDN->getDisplay()->setDrawColor(1);
+    PDN->getDisplay()->drawFrame(barX, barY, barWidth, barHeight);
+    PDN->getDisplay()->drawBox(barX + 1, barY + 1, fillWidth, barHeight - 2);
+
+    // Draw grid
+    renderGrid(PDN, gridX, gridY);
+
+    // Draw bottom bar: button labels
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)
+        ->drawText("\x1E next", 4, 60)
+        ->drawText("\x1F rotate", 70, 60);
+
     PDN->getDisplay()->render();
+}
+
+/*
+ * Render the wire grid with energized tiles, flow front, and cursor highlight.
+ */
+void CipherPathGameplay::renderGrid(Device* PDN, int gridX, int gridY) {
+    auto& config = game->getConfig();
+    auto& session = game->getSession();
+
+    // Draw grid frame and lines
+    PDN->getDisplay()->setDrawColor(1);
+    PDN->getDisplay()->drawFrame(gridX, gridY, config.cols * CELL_PITCH + 1, config.rows * CELL_PITCH + 1);
+
+    // Draw vertical grid lines
+    for (int col = 1; col < config.cols; col++) {
+        int x = gridX + col * CELL_PITCH;
+        PDN->getDisplay()->drawBox(x, gridY + 1, 1, config.rows * CELL_PITCH - 1);
+    }
+
+    // Draw horizontal grid lines
+    for (int row = 1; row < config.rows; row++) {
+        int y = gridY + row * CELL_PITCH;
+        PDN->getDisplay()->drawBox(gridX + 1, y, config.cols * CELL_PITCH - 1, 1);
+    }
+
+    // Draw all tiles
+    for (int row = 0; row < config.rows; row++) {
+        for (int col = 0; col < config.cols; col++) {
+            int cellIndex = row * config.cols + col;
+            int cellX = gridX + col * CELL_PITCH + 1;
+            int cellY = gridY + row * CELL_PITCH + 1;
+
+            // Determine if this tile is the cursor position
+            int cursorCellIndex = -1;
+            for (int i = 0; i < 35; i++) {
+                if (session.pathOrder[i] == session.cursorPathIndex) {
+                    cursorCellIndex = i;
+                    break;
+                }
+            }
+            bool isCursor = (cellIndex == cursorCellIndex) && cursorVisible;
+
+            // Determine if this tile is energized (electricity has passed through)
+            int tilePathIndex = session.pathOrder[cellIndex];
+            bool isEnergized = (tilePathIndex != -1 && tilePathIndex < session.flowTileIndex);
+
+            // Determine if this is the flow front tile
+            int flowPixel = (tilePathIndex == session.flowTileIndex) ? session.flowPixelInTile : -1;
+
+            renderTile(PDN, cellX, cellY, cellIndex, isCursor, isEnergized, flowPixel);
+        }
+    }
+}
+
+/*
+ * Render a single tile with cursor highlight, energization, and flow front effects.
+ */
+void CipherPathGameplay::renderTile(Device* PDN, int cellX, int cellY, int cellIndex, bool isCursor, bool isEnergized, int flowPixel) {
+    auto& session = game->getSession();
+
+    int tileType = session.tileType[cellIndex];
+    int rotation = session.tileRotation[cellIndex];
+
+    if (tileType == TILE_EMPTY) {
+        // Draw cursor highlight on empty cell if cursor is here (shouldn't happen, but safety)
+        if (isCursor) {
+            PDN->getDisplay()->setDrawColor(2);  // XOR for blinking cursor
+            PDN->getDisplay()->drawFrame(cellX, cellY, CELL_INNER, CELL_INNER);
+        }
+        return;
+    }
+
+    // Determine wire width
+    bool isPath = (session.pathOrder[cellIndex] != -1);
+    int wireWidth = isPath ? WIRE_WIDTH : NOISE_WIDTH;
+
+    // Render tile (with energization inversion if needed)
+    bool invert = isEnergized;
+    renderWireTile(PDN, cellX, cellY, tileType, rotation, wireWidth, invert);
+
+    // Cursor highlight (XOR frame around cell)
+    if (isCursor) {
+        PDN->getDisplay()->setDrawColor(2);  // XOR
+        PDN->getDisplay()->drawFrame(cellX - 1, cellY - 1, CELL_INNER + 2, CELL_INNER + 2);
+    }
+}
+
+/*
+ * Render a wire tile with optional inversion (for energized tiles).
+ * Inversion: white cell background with black wire channels (glowing effect).
+ */
+void CipherPathGameplay::renderWireTile(Device* PDN, int x, int y, int tileType, int rotation, int wireWidth, bool invert) {
+    int connections = getTileConnections(tileType, rotation);
+
+    if (invert) {
+        // Energized tile: fill cell with white, draw black wire channels
+        PDN->getDisplay()->setDrawColor(1);
+        PDN->getDisplay()->drawBox(x, y, CELL_INNER, CELL_INNER);
+        PDN->getDisplay()->setDrawColor(0);  // Black wire channels
+    } else {
+        // Normal tile: black background, white wire
+        PDN->getDisplay()->setDrawColor(1);
+    }
+
+    // Wire center position
+    int centerStart = (CELL_INNER - wireWidth) / 2;
+    int centerEnd = centerStart + wireWidth;
+
+    // Draw wire segments
+    if (connections & DIR_UP) {
+        PDN->getDisplay()->drawBox(x + centerStart, y, wireWidth, centerEnd);
+    }
+    if (connections & DIR_RIGHT) {
+        PDN->getDisplay()->drawBox(x + centerStart, y + centerStart, CELL_INNER - centerStart, wireWidth);
+    }
+    if (connections & DIR_DOWN) {
+        PDN->getDisplay()->drawBox(x + centerStart, y + centerStart, wireWidth, CELL_INNER - centerStart);
+    }
+    if (connections & DIR_LEFT) {
+        PDN->getDisplay()->drawBox(x, y + centerStart, centerEnd, wireWidth);
+    }
+
+    // Reset draw color to normal
+    PDN->getDisplay()->setDrawColor(1);
 }

--- a/src/game/cipher-path/cipher-path-intro.cpp
+++ b/src/game/cipher-path/cipher-path-intro.cpp
@@ -26,11 +26,11 @@ void CipherPathIntro::onStateMounted(Device* PDN) {
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
     game->seedRng(game->getConfig().rngSeed);
 
-    // Display title screen
+    // Display title screen with new subtitle
     PDN->getDisplay()->invalidateScreen();
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
         ->drawText("CIPHER PATH", 10, 20)
-        ->drawText("Decode the route.", 10, 45);
+        ->drawText("Route the signal.", 10, 45);
     PDN->getDisplay()->render();
 
     // Start idle LED animation
@@ -43,11 +43,31 @@ void CipherPathIntro::onStateMounted(Device* PDN) {
     config.loop = true;
     PDN->getLightManager()->startAnimation(config);
 
-    // Start intro timer
+    // Start intro timer and animation timer
     introTimer.setTimer(INTRO_DURATION_MS);
+    animTimer.setTimer(150);  // Flash circuit elements every 150ms
 }
 
 void CipherPathIntro::onStateLoop(Device* PDN) {
+    // Simple circuit flash animation — random wire segments flash on/off
+    if (animTimer.expired()) {
+        // Draw a few random small wire segments to create "circuit board" effect
+        PDN->getDisplay()->setDrawColor(1);
+        for (int i = 0; i < 8; i++) {
+            int x = 10 + (rand() % 100);
+            int y = 8 + (rand() % 48);
+            int w = 3 + (rand() % 8);
+            bool horiz = (rand() % 2) == 0;
+            if (horiz) {
+                PDN->getDisplay()->drawBox(x, y, w, 1);
+            } else {
+                PDN->getDisplay()->drawBox(x, y, 1, w);
+            }
+        }
+        PDN->getDisplay()->render();
+        animTimer.setTimer(150);
+    }
+
     if (introTimer.expired()) {
         transitionToShowState = true;
     }
@@ -55,6 +75,7 @@ void CipherPathIntro::onStateLoop(Device* PDN) {
 
 void CipherPathIntro::onStateDismounted(Device* PDN) {
     introTimer.invalidate();
+    animTimer.invalidate();
     transitionToShowState = false;
 }
 

--- a/src/game/cipher-path/cipher-path-lose.cpp
+++ b/src/game/cipher-path/cipher-path-lose.cpp
@@ -24,11 +24,12 @@ void CipherPathLose::onStateMounted(Device* PDN) {
     loseOutcome.hardMode = false;
     game->setOutcome(loseOutcome);
 
-    LOG_I(TAG, "PATH LOST (score=%d)", session.score);
+    LOG_I(TAG, "CIRCUIT BREAK (score=%d)", session.score);
 
+    // Initial spark animation: full screen flash
     PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("PATH LOST", 10, 30);
+    PDN->getDisplay()->setDrawColor(1);
+    PDN->getDisplay()->drawBox(0, 0, 128, 64);  // Full white flash
     PDN->getDisplay()->render();
 
     // Lose LED animation
@@ -41,12 +42,48 @@ void CipherPathLose::onStateMounted(Device* PDN) {
     animConfig.loop = true;
     PDN->getLightManager()->startAnimation(animConfig);
 
+    // Full haptic surge (electrical shock effect)
     PDN->getHaptics()->setIntensity(255);
 
     loseTimer.setTimer(LOSE_DISPLAY_MS);
+    sparkTimer.setTimer(SPARK_FLASH_MS);
+    sparkFlashCount = 0;
 }
 
 void CipherPathLose::onStateLoop(Device* PDN) {
+    // Spark flash animation (3 flashes total)
+    if (sparkFlashCount < 3 && sparkTimer.expired()) {
+        sparkFlashCount++;
+
+        // Toggle screen inversion for spark effect
+        if (sparkFlashCount % 2 == 1) {
+            // Flash: white screen
+            PDN->getDisplay()->invalidateScreen();
+            PDN->getDisplay()->setDrawColor(1);
+            PDN->getDisplay()->drawBox(0, 0, 128, 64);
+            PDN->getDisplay()->render();
+        } else {
+            // Back to text display
+            PDN->getDisplay()->invalidateScreen();
+            PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+                ->drawText("CIRCUIT", 20, 20)
+                ->drawText("BREAK", 30, 40);
+            PDN->getDisplay()->render();
+        }
+
+        sparkTimer.setTimer(SPARK_FLASH_MS);
+    }
+
+    // Final text display after sparks
+    if (sparkFlashCount == 3 && sparkTimer.expired()) {
+        PDN->getDisplay()->invalidateScreen();
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
+            ->drawText("CIRCUIT", 20, 20)
+            ->drawText("BREAK", 30, 40);
+        PDN->getDisplay()->render();
+        sparkFlashCount = 4;  // Prevent re-rendering
+    }
+
     if (loseTimer.expired()) {
         PDN->getHaptics()->off();
         if (!game->getConfig().managedMode) {
@@ -59,7 +96,9 @@ void CipherPathLose::onStateLoop(Device* PDN) {
 
 void CipherPathLose::onStateDismounted(Device* PDN) {
     loseTimer.invalidate();
+    sparkTimer.invalidate();
     transitionToIntroState = false;
+    sparkFlashCount = 0;
     PDN->getHaptics()->off();
 }
 

--- a/src/game/cipher-path/cipher-path-show.cpp
+++ b/src/game/cipher-path/cipher-path-show.cpp
@@ -20,30 +20,25 @@ void CipherPathShow::onStateMounted(Device* PDN) {
     auto& session = game->getSession();
     auto& config = game->getConfig();
 
-    // Generate cipher for this round
-    game->generateCipher();
+    // Generate path and noise tiles for this round
+    game->generatePath();
+    game->generateNoise();
 
-    // Reset per-round state
-    session.playerPosition = 0;
-    session.movesUsed = 0;
+    // Reset flow state
+    session.flowTileIndex = 0;
+    session.flowPixelInTile = 0;
+    session.flowActive = false;
+    session.cursorPathIndex = 0;
 
     LOG_I(TAG, "Round %d of %d", session.currentRound + 1, config.rounds);
 
-    // Display round info
-    std::string roundText = "Round " + std::to_string(session.currentRound + 1)
-                          + " of " + std::to_string(config.rounds);
-    std::string moveText = "Moves: 0/" + std::to_string(config.moveBudget);
-
-    PDN->getDisplay()->invalidateScreen();
-    PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText(roundText.c_str(), 10, 20)
-        ->drawText(moveText.c_str(), 10, 45);
-    PDN->getDisplay()->render();
+    // Render the grid preview
+    renderShowScreen(PDN);
 
     // Haptic pulse feedback
     PDN->getHaptics()->setIntensity(100);
 
-    // Start show timer
+    // Start show timer (2 seconds preview)
     showTimer.setTimer(SHOW_DURATION_MS);
 }
 
@@ -62,4 +57,126 @@ void CipherPathShow::onStateDismounted(Device* PDN) {
 
 bool CipherPathShow::transitionToGameplay() {
     return transitionToGameplayState;
+}
+
+/*
+ * Render show screen: grid with scrambled tiles + round pips (hard mode).
+ * Grid is centered on screen with HUD panel on the right.
+ */
+void CipherPathShow::renderShowScreen(Device* PDN) {
+    auto& config = game->getConfig();
+    auto& session = game->getSession();
+
+    PDN->getDisplay()->invalidateScreen();
+
+    // Calculate grid position (center-left on screen)
+    int gridWidth = config.cols * CELL_PITCH + 1;
+    int gridHeight = config.rows * CELL_PITCH + 1;
+    int gridX = 4;  // Left margin
+    int gridY = (64 - gridHeight) / 2;  // Vertically centered
+
+    // Draw top bar with round pips (hard mode only)
+    if (config.rounds > 1) {
+        PDN->getDisplay()->setGlyphMode(FontMode::TEXT);
+        int pipX = 4;
+        for (int i = 0; i < config.rounds; i++) {
+            const char* pip = (i < session.currentRound) ? "\x07" : "\x08";  // Filled / empty circle
+            PDN->getDisplay()->drawText(pip, pipX, 3);
+            pipX += 8;
+        }
+    }
+
+    // Draw the grid
+    renderGrid(PDN, gridX, gridY);
+
+    // Right HUD panel: game title (vertical or small)
+    PDN->getDisplay()->setGlyphMode(FontMode::TEXT_INVERTED_SMALL)
+        ->drawText("CIPHER", gridX + gridWidth + 8, 20)
+        ->drawText("PATH", gridX + gridWidth + 8, 32);
+
+    PDN->getDisplay()->render();
+}
+
+/*
+ * Render the wire grid with all tiles in their current (scrambled) orientations.
+ */
+void CipherPathShow::renderGrid(Device* PDN, int gridX, int gridY) {
+    auto& config = game->getConfig();
+
+    // Draw grid frame and lines
+    PDN->getDisplay()->setDrawColor(1);
+    PDN->getDisplay()->drawFrame(gridX, gridY, config.cols * CELL_PITCH + 1, config.rows * CELL_PITCH + 1);
+
+    // Draw vertical grid lines
+    for (int col = 1; col < config.cols; col++) {
+        int x = gridX + col * CELL_PITCH;
+        PDN->getDisplay()->drawBox(x, gridY + 1, 1, config.rows * CELL_PITCH - 1);
+    }
+
+    // Draw horizontal grid lines
+    for (int row = 1; row < config.rows; row++) {
+        int y = gridY + row * CELL_PITCH;
+        PDN->getDisplay()->drawBox(gridX + 1, y, config.cols * CELL_PITCH - 1, 1);
+    }
+
+    // Draw all tiles
+    for (int row = 0; row < config.rows; row++) {
+        for (int col = 0; col < config.cols; col++) {
+            int cellIndex = row * config.cols + col;
+            int cellX = gridX + col * CELL_PITCH + 1;
+            int cellY = gridY + row * CELL_PITCH + 1;
+            renderTile(PDN, cellX, cellY, cellIndex);
+        }
+    }
+}
+
+/*
+ * Render a single tile at the given screen position.
+ */
+void CipherPathShow::renderTile(Device* PDN, int cellX, int cellY, int cellIndex) {
+    auto& session = game->getSession();
+
+    int tileType = session.tileType[cellIndex];
+    int rotation = session.tileRotation[cellIndex];
+
+    if (tileType == TILE_EMPTY) return;  // Skip empty cells
+
+    // Determine wire width: path tiles are bold (2px), noise tiles are thin (1px)
+    bool isPath = (session.pathOrder[cellIndex] != -1);
+    int wireWidth = isPath ? WIRE_WIDTH : NOISE_WIDTH;
+
+    renderWireTile(PDN, cellX, cellY, tileType, rotation, wireWidth);
+}
+
+/*
+ * Render a wire tile with the specified type, rotation, and wire width.
+ * Draws wire segments using drawBox primitives. Uses direction bitmask
+ * from getTileConnections() to determine which segments to draw.
+ */
+void CipherPathShow::renderWireTile(Device* PDN, int x, int y, int tileType, int rotation, int wireWidth) {
+    int connections = getTileConnections(tileType, rotation);
+
+    PDN->getDisplay()->setDrawColor(1);  // White wire on black background
+
+    // Wire center position within 8x8 cell (centered at pixels 3-4 for 2px wire)
+    int centerStart = (CELL_INNER - wireWidth) / 2;  // 3 for 2px, 3.5->3 for 1px
+    int centerEnd = centerStart + wireWidth;
+
+    // Draw wire segments based on connection bitmask
+    if (connections & DIR_UP) {
+        // Vertical segment from top edge to center
+        PDN->getDisplay()->drawBox(x + centerStart, y, wireWidth, centerEnd);
+    }
+    if (connections & DIR_RIGHT) {
+        // Horizontal segment from center to right edge
+        PDN->getDisplay()->drawBox(x + centerStart, y + centerStart, CELL_INNER - centerStart, wireWidth);
+    }
+    if (connections & DIR_DOWN) {
+        // Vertical segment from center to bottom edge
+        PDN->getDisplay()->drawBox(x + centerStart, y + centerStart, wireWidth, CELL_INNER - centerStart);
+    }
+    if (connections & DIR_LEFT) {
+        // Horizontal segment from left edge to center
+        PDN->getDisplay()->drawBox(x, y + centerStart, centerEnd, wireWidth);
+    }
 }

--- a/src/game/cipher-path/cipher-path-win.cpp
+++ b/src/game/cipher-path/cipher-path-win.cpp
@@ -19,8 +19,8 @@ void CipherPathWin::onStateMounted(Device* PDN) {
     auto& config = game->getConfig();
     auto& session = game->getSession();
 
-    // Determine hard mode: tight budget on long grid
-    bool isHard = (config.gridSize >= 10 && config.moveBudget <= 14);
+    // Determine hard mode: 7x5 grid or 3 rounds
+    bool isHard = (config.cols >= 7 || config.rounds >= 3);
 
     MiniGameOutcome winOutcome;
     winOutcome.result = MiniGameResult::WON;
@@ -28,11 +28,12 @@ void CipherPathWin::onStateMounted(Device* PDN) {
     winOutcome.hardMode = isHard;
     game->setOutcome(winOutcome);
 
-    LOG_I(TAG, "PATH DECODED (score=%d, hard=%d)", session.score, isHard);
+    LOG_I(TAG, "CIRCUIT ROUTED (score=%d, hard=%d)", session.score, isHard);
 
     PDN->getDisplay()->invalidateScreen();
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("PATH DECODED", 10, 30);
+        ->drawText("CIRCUIT", 20, 20)
+        ->drawText("ROUTED", 30, 40);
     PDN->getDisplay()->render();
 
     // Win LED animation

--- a/src/game/cipher-path/cipher-path.cpp
+++ b/src/game/cipher-path/cipher-path.cpp
@@ -1,5 +1,6 @@
 #include "game/cipher-path/cipher-path.hpp"
 #include "game/cipher-path/cipher-path-states.hpp"
+#include "game/cipher-path/cipher-path-resources.hpp"
 
 void CipherPath::populateStateMap() {
     seedRng(config.rngSeed);
@@ -72,8 +73,206 @@ void CipherPath::resetGame() {
     session.reset();
 }
 
-void CipherPath::generateCipher() {
-    for (int i = 0; i < config.gridSize; i++) {
-        session.cipher[i] = rand() % 2;  // 0 = UP correct, 1 = DOWN correct
+/*
+ * Generate path using random walk with directional bias toward target.
+ * Algorithm: Start at (0,0), end at (cols-1, rows-1). At each step,
+ * 60% chance to move toward target (reducing Manhattan distance),
+ * 40% chance to pick random unvisited neighbor. Backtrack on dead ends.
+ * Result: a meandering but solvable path from input to output terminal.
+ */
+void CipherPath::generatePath() {
+    auto& sess = session;
+    auto& cfg = config;
+
+    // Clear session state
+    for (int i = 0; i < 35; i++) {
+        sess.tileType[i] = TILE_EMPTY;
+        sess.tileRotation[i] = 0;
+        sess.correctRotation[i] = 0;
+        sess.pathOrder[i] = -1;
+    }
+    sess.pathLength = 0;
+    sess.flowTileIndex = 0;
+    sess.flowPixelInTile = 0;
+    sess.flowActive = false;
+    sess.cursorPathIndex = 0;
+
+    // Path generation via random walk
+    int path[35];          // Grid indices along the path
+    bool visited[35];      // Track which cells have been visited
+    for (int i = 0; i < 35; i++) visited[i] = false;
+
+    int pathLen = 0;
+    int targetX = cfg.cols - 1;
+    int targetY = cfg.rows - 1;
+    int targetIndex = targetY * cfg.cols + targetX;
+
+    path[pathLen++] = 0;   // Start at (0, 0)
+    visited[0] = true;
+    int currentIndex = 0;
+
+    // Random walk until we reach target
+    while (currentIndex != targetIndex) {
+        int cx = currentIndex % cfg.cols;
+        int cy = currentIndex / cfg.cols;
+
+        // Find unvisited neighbors (up, right, down, left)
+        int neighbors[4];
+        int neighborCount = 0;
+
+        // Up
+        if (cy > 0 && !visited[currentIndex - cfg.cols]) {
+            neighbors[neighborCount++] = currentIndex - cfg.cols;
+        }
+        // Right
+        if (cx < cfg.cols - 1 && !visited[currentIndex + 1]) {
+            neighbors[neighborCount++] = currentIndex + 1;
+        }
+        // Down
+        if (cy < cfg.rows - 1 && !visited[currentIndex + cfg.cols]) {
+            neighbors[neighborCount++] = currentIndex + cfg.cols;
+        }
+        // Left
+        if (cx > 0 && !visited[currentIndex - 1]) {
+            neighbors[neighborCount++] = currentIndex - 1;
+        }
+
+        if (neighborCount == 0) {
+            // Dead end — backtrack
+            pathLen--;
+            if (pathLen == 0) break;  // Shouldn't happen, but safety check
+            currentIndex = path[pathLen - 1];
+            continue;
+        }
+
+        // Choose next cell: 60% bias toward target, 40% random
+        int nextIndex;
+        if (rand() % 100 < 60) {
+            // Pick neighbor that reduces Manhattan distance to target
+            int bestDist = 9999;
+            int bestNeighbor = neighbors[0];
+            for (int i = 0; i < neighborCount; i++) {
+                int nx = neighbors[i] % cfg.cols;
+                int ny = neighbors[i] / cfg.cols;
+                int dist = (targetX - nx > 0 ? targetX - nx : nx - targetX)
+                         + (targetY - ny > 0 ? targetY - ny : ny - targetY);
+                if (dist < bestDist) {
+                    bestDist = dist;
+                    bestNeighbor = neighbors[i];
+                }
+            }
+            nextIndex = bestNeighbor;
+        } else {
+            // Random neighbor
+            nextIndex = neighbors[rand() % neighborCount];
+        }
+
+        path[pathLen++] = nextIndex;
+        visited[nextIndex] = true;
+        currentIndex = nextIndex;
+    }
+
+    // Assign tile types and rotations based on path
+    sess.pathLength = pathLen;
+    for (int i = 0; i < pathLen; i++) {
+        int idx = path[i];
+        sess.pathOrder[idx] = i;
+
+        int x = idx % cfg.cols;
+        int y = idx / cfg.cols;
+
+        // Determine entry and exit directions
+        int entryDir = -1;  // -1 = none (input terminal)
+        int exitDir = -1;   // -1 = none (output terminal)
+
+        if (i > 0) {
+            int prevIdx = path[i - 1];
+            int px = prevIdx % cfg.cols;
+            int py = prevIdx / cfg.cols;
+            if (px < x) entryDir = 3;  // Entry from left (DIR_LEFT)
+            else if (px > x) entryDir = 1;  // Entry from right (DIR_RIGHT)
+            else if (py < y) entryDir = 0;  // Entry from up (DIR_UP)
+            else entryDir = 2;  // Entry from down (DIR_DOWN)
+        }
+
+        if (i < pathLen - 1) {
+            int nextIdx = path[i + 1];
+            int nx = nextIdx % cfg.cols;
+            int ny = nextIdx / cfg.cols;
+            if (nx < x) exitDir = 3;  // Exit to left
+            else if (nx > x) exitDir = 1;  // Exit to right
+            else if (ny < y) exitDir = 0;  // Exit to up
+            else exitDir = 2;  // Exit to down
+        }
+
+        // Assign tile type and correct rotation
+        if (i == 0) {
+            // Input terminal (endpoint pointing toward next tile)
+            sess.tileType[idx] = TILE_ENDPOINT;
+            sess.correctRotation[idx] = exitDir;
+        } else if (i == pathLen - 1) {
+            // Output terminal (endpoint pointing back toward previous tile)
+            sess.tileType[idx] = TILE_ENDPOINT;
+            // Endpoint needs to point INTO the cell, so invert entry direction
+            sess.correctRotation[idx] = (entryDir + 2) % 4;
+        } else {
+            // Internal path tile
+            if ((entryDir + 2) % 4 == exitDir) {
+                // Straight tile (opposite edges)
+                sess.tileType[idx] = TILE_STRAIGHT;
+                // Rotation: align entry to DIR_LEFT (base rotation)
+                sess.correctRotation[idx] = (entryDir - 3 + 4) % 4;
+            } else {
+                // Elbow tile (adjacent edges)
+                sess.tileType[idx] = TILE_ELBOW;
+                // Base elbow: DIR_UP | DIR_RIGHT (connections 0x03)
+                // Find rotation where entry and exit match
+                for (int rot = 0; rot < 4; rot++) {
+                    int conn = getTileConnections(TILE_ELBOW, rot);
+                    int entryBit = 1 << entryDir;
+                    int exitBit = 1 << exitDir;
+                    if ((conn & entryBit) && (conn & exitBit)) {
+                        sess.correctRotation[idx] = rot;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // Scramble non-terminal tiles
+        if (i == 0 || i == pathLen - 1) {
+            // Terminals are FIXED (always correct orientation)
+            sess.tileRotation[idx] = sess.correctRotation[idx];
+        } else {
+            // Scramble: rotate by 1, 2, or 3 steps (never 0)
+            int offset = 1 + (rand() % 3);
+            sess.tileRotation[idx] = (sess.correctRotation[idx] + offset) % 4;
+        }
+    }
+}
+
+/*
+ * Add noise tiles to non-path cells. Noise tiles are thin (1px) decorative
+ * wire segments that create visual complexity. They don't carry electricity
+ * and the cursor skips them. noisePercent (30% easy, 40% hard) of non-path
+ * cells get random wire segments.
+ */
+void CipherPath::generateNoise() {
+    auto& sess = session;
+    auto& cfg = config;
+
+    int totalCells = cfg.cols * cfg.rows;
+    for (int i = 0; i < totalCells; i++) {
+        // Skip path tiles
+        if (sess.pathOrder[i] != -1) continue;
+
+        // noisePercent chance to place a noise tile
+        if (rand() % 100 < cfg.noisePercent) {
+            // Random tile type: straight, elbow, t-junction, or cross
+            int type = 1 + (rand() % 4);  // 1-4 (STRAIGHT to CROSS)
+            sess.tileType[i] = type;
+            sess.tileRotation[i] = rand() % 4;
+            sess.correctRotation[i] = 0;  // Noise tiles don't have a "correct" rotation
+        }
     }
 }


### PR DESCRIPTION
BioShock-inspired wire rotation puzzle with real-time electricity flow. Transform from text-only binary-guess into visual grid puzzle. 5 tile types, 9px cells with bold/thin wires. Easy: 5x4/1 round/200ms flow. Hard: 7x5/3 rounds/80ms→60ms escalation. Terminals fixed, tiles scrambled, cursor navigation (UP=next, DOWN=rotate). Energized tiles invert (glowing effect). Circuit break = spark animation + haptic surge. Closes #242.