### PR TITLE
feat: Color Palette Menu visual redesign (#261)

### DIFF
--- a/.agent-checkpoint.json
+++ b/.agent-checkpoint.json
@@ -1,0 +1,49 @@
+{
+  "timestamp": "2026-02-16T07:51:39Z",
+  "branch": "wave18b/09-color-palette-redesign",
+  "last_commit": "472f8c4 fix: repair 4 test failures from Wave 17 merges",
+  "progress": "Code compiles successfully (native_cli build passed). Tests crash on pre-existing comprehensive-integration-tests segfault before reaching color profile tests",
+  "phase": "working",
+  "steps_completed": 7,
+  "files_changed": 5,
+  "staged_files": 0,
+  "uncommitted_changes": "include/game/quickdraw-states.hpp,src/game/quickdraw-states/color-profile-picker.cpp,src/game/quickdraw-states/idle-state.cpp,test/test_cli/color-profile-tests.hpp,test/test_cli/fdn-integration-tests.cpp,",
+  "claude_pid": 202378,
+  "step_log": [
+    {
+      "step": 1,
+      "time": "2026-02-16T07:47:03Z",
+      "progress": "Read plan and current state. Task: Color Palette Menu visual redesign. Files to modify: idle-state.cpp, color-profile-picker.cpp, quickdraw-states.hpp, player.hpp (add hasHardModeUnlocked if needed), and tests."
+    },
+    {
+      "step": 2,
+      "time": "2026-02-16T07:47:16Z",
+      "progress": "Modified idle-state.cpp: changed color picker access guard from eligibility check to hasHardModeUnlocked()"
+    },
+    {
+      "step": 3,
+      "time": "2026-02-16T07:47:26Z",
+      "progress": "Added ledPreviewRequested flag to ColorProfilePicker class in quickdraw-states.hpp"
+    },
+    {
+      "step": 4,
+      "time": "2026-02-16T07:48:11Z",
+      "progress": "Completed visual redesign of color-profile-picker.cpp: added inverted highlight, separators, LED preview, centered scrolling"
+    },
+    {
+      "step": 5,
+      "time": "2026-02-16T07:49:03Z",
+      "progress": "Updated tests in color-profile-tests.hpp and fdn-integration-tests.cpp: changed access guard tests to use hasHardModeUnlocked(), added 4 new tests for visual redesign and LED preview"
+    },
+    {
+      "step": 6,
+      "time": "2026-02-16T07:50:17Z",
+      "progress": "Fixed test methods to use available driver APIs (removed getSetStateCallCount and getBoxHistory, using getLight and text history instead)"
+    },
+    {
+      "step": 7,
+      "time": "2026-02-16T07:51:39Z",
+      "progress": "Code compiles successfully (native_cli build passed). Tests crash on pre-existing comprehensive-integration-tests segfault before reaching color profile tests"
+    }
+  ]
+}

--- a/include/game/quickdraw-states.hpp
+++ b/include/game/quickdraw-states.hpp
@@ -428,6 +428,7 @@ private:
     ProgressManager* progressManager;
     bool transitionToIdleState = false;
     bool displayIsDirty = false;
+    bool ledPreviewRequested = false;
     int cursorIndex = 0;
     std::vector<int> profileList;  // game type values (-1 = DEFAULT)
     void buildProfileList();

--- a/src/game/quickdraw-states/idle-state.cpp
+++ b/src/game/quickdraw-states/idle-state.cpp
@@ -74,8 +74,8 @@ void Idle::onStateMounted(Device *PDN) {
     PDN->getPrimaryButton()->setButtonPress(cycleStats, this, ButtonInteraction::CLICK);
     PDN->getSecondaryButton()->setButtonPress(cycleStats, this, ButtonInteraction::CLICK);
 
-    // Long press secondary → color profile picker (only if player has eligible profiles)
-    if (!player->getColorProfileEligibility().empty()) {
+    // Long press secondary → color profile picker (accessible after Konami code)
+    if (player->hasHardModeUnlocked()) {
         parameterizedCallbackFunction longPressCb = [](void *ctx) {
             Idle* idle = (Idle*)ctx;
             idle->colorPickerRequested = true;

--- a/test/test_cli/fdn-integration-tests.cpp
+++ b/test/test_cli/fdn-integration-tests.cpp
@@ -295,6 +295,22 @@ TEST_F(ColorProfilePickerTestSuite, PreselectsEquipped) {
     colorProfilePickerPreselectsEquipped(this);
 }
 
+TEST_F(ColorProfilePickerTestSuite, ShowsDefaultOnly) {
+    colorProfilePickerShowsDefaultOnly(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, LedPreview) {
+    colorProfilePickerLedPreview(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, VisualRedesign) {
+    colorProfilePickerVisualRedesign(this);
+}
+
+TEST_F(ColorProfilePickerTestSuite, ControlLabel) {
+    colorProfilePickerControlLabel(this);
+}
+
 // ============================================
 // FDN COMPLETE ROUTING TESTS
 // ============================================


### PR DESCRIPTION
Visual redesign of ColorProfilePicker to match universal minigame visual language.

## Changes

### 1. Unlock Trigger (idle-state.cpp)
Changed color picker access guard from `!player->getColorProfileEligibility().empty()` to `player->hasHardModeUnlocked()`. This makes the menu accessible after Konami code entry, even before earning any palettes.

### 2. Visual Redesign (color-profile-picker.cpp)
- **3-region layout**: Header | Content | Controls
- **Inverted highlight**: Selected option has white background + black text (`drawBox` + `setDrawColor(0)`)
- **Separators**: Header separator at y=14, footer separator at y=54
- **Control labels**: "[UP] CYCLE  [DOWN] SELECT"
- **Centered scrolling**: Cursor stays centered in 3-item visible window

### 3. LED Preview (onStateLoop)
When cycling to a new palette option, previews the color on LEDs:
- Game-specific palette: shows the color profile LEDState
- DEFAULT: shows role-based idle LED (hunter or bounty)

### 4. Header Flag (quickdraw-states.hpp)
Added `bool ledPreviewRequested` to ColorProfilePicker class.

### 5. Tests (color-profile-tests.hpp + fdn-integration-tests.cpp)
- Updated `idleLongPressEntersPicker`: uses `unlockHardMode()` instead of adding eligibility
- Updated `idleLongPressNoPickerWithoutEligibility`: verifies no access before Konami code
- Added `colorProfilePickerShowsDefaultOnly`: verifies DEFAULT option shown when no palettes earned
- Added `colorProfilePickerLedPreview`: verifies LED state changes on cycle
- Added `colorProfilePickerVisualRedesign`: verifies new control text format
- Added `colorProfilePickerControlLabel`: verifies "[UP] CYCLE" and "[DOWN] SELECT" text

## Build Status
CLI build passes (`pio run -e native_cli`)

## Test Status
Tests cannot fully run due to pre-existing segfault in comprehensive-integration-tests (before color profile tests execute). This is a known issue not introduced by this PR.

Closes #261