### PR TITLE
fix: disable 61 broken tests from Wave 18 API changes (#284)

### DIFF
--- a/test/test_cli/cipher-path-reg-tests.cpp
+++ b/test/test_cli/cipher-path-reg-tests.cpp
@@ -1,23 +1,85 @@
 //
 // Cipher Path Tests — Registration file for Cipher Path minigame
 //
+// NOTE: Tests temporarily disabled during Wave 18 redesign (#242)
+// Cipher Path was redesigned from a binary cipher path to a wire routing puzzle.
+// The old API (cipher[], playerPosition, movesUsed, moveBudget, gridSize)
+// was completely replaced with tile-based grid API (tileType[], tileRotation[],
+// cursorPathIndex, flowTileIndex, flowActive).
+// Tests need complete rewrite for the new wire rotation mechanics.
+//
+// TODO(#242): Rewrite tests for wire routing puzzle mechanics
 
 #include <gtest/gtest.h>
 
-#include "cipher-path-tests.hpp"
+// Temporarily not including header since all gameplay tests disabled
+// #include "cipher-path-tests.hpp"
+
+// Minimal includes for config tests only
+#include "game/cipher-path/cipher-path.hpp"
 
 // ============================================
-// CIPHER PATH TESTS
+// CIPHER PATH TESTS — TEMPORARILY DISABLED
 // ============================================
 
+// Minimal test suite for basic sanity checks
+class CipherPathTestSuite : public testing::Test {
+public:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// Config tests updated for new Wire Routing API
 TEST_F(CipherPathTestSuite, EasyConfigPresets) {
-    cipherPathEasyConfigPresets(this);
+    CipherPathConfig easy = CIPHER_PATH_EASY;
+    ASSERT_EQ(easy.cols, 5);
+    ASSERT_EQ(easy.rows, 4);
+    ASSERT_EQ(easy.rounds, 1);
+    ASSERT_EQ(easy.flowSpeedMs, 200);
+    ASSERT_EQ(easy.flowSpeedDecayMs, 0);
+    ASSERT_EQ(easy.noisePercent, 30);
 }
 
 TEST_F(CipherPathTestSuite, HardConfigPresets) {
-    cipherPathHardConfigPresets(this);
+    CipherPathConfig hard = CIPHER_PATH_HARD;
+    ASSERT_EQ(hard.cols, 7);
+    ASSERT_EQ(hard.rows, 5);
+    ASSERT_EQ(hard.rounds, 3);
+    ASSERT_EQ(hard.flowSpeedMs, 80);
+    ASSERT_EQ(hard.flowSpeedDecayMs, 10);
+    ASSERT_EQ(hard.noisePercent, 40);
 }
 
+TEST_F(CipherPathTestSuite, SessionResetClearsState) {
+    CipherPathSession session;
+    session.currentRound = 2;
+    session.score = 50;
+    session.pathLength = 10;
+    session.flowTileIndex = 5;
+    session.flowPixelInTile = 3;
+    session.flowActive = true;
+    session.cursorPathIndex = 7;
+
+    session.reset();
+
+    ASSERT_EQ(session.currentRound, 0);
+    ASSERT_EQ(session.score, 0);
+    ASSERT_EQ(session.pathLength, 0);
+    ASSERT_EQ(session.flowTileIndex, 0);
+    ASSERT_EQ(session.flowPixelInTile, 0);
+    ASSERT_FALSE(session.flowActive);
+    ASSERT_EQ(session.cursorPathIndex, 0);
+    // Verify tile arrays are cleared
+    for (int i = 0; i < 35; i++) {
+        ASSERT_EQ(session.tileType[i], 0);
+        ASSERT_EQ(session.tileRotation[i], 0);
+        ASSERT_EQ(session.correctRotation[i], 0);
+        ASSERT_EQ(session.pathOrder[i], -1);
+    }
+}
+
+// All gameplay tests disabled pending rewrite for wire routing mechanics
+/*
 TEST_F(CipherPathTestSuite, IntroResetsSession) {
     cipherPathIntroResetsSession(this);
 }
@@ -98,16 +160,9 @@ TEST_F(CipherPathTestSuite, MoveFromStartBoundary) {
     cipherPathMoveFromStartBoundary(this);
 }
 
-// DISABLED: Wave 17 KonamiMetaGame routing changed (Issue #271)
-// After minigame completes, app transition flow (KonamiMetaGame → resume → FdnComplete) doesn't
-// match test expectations. Re-enable after verifying managed mode return flow.
 TEST_F(CipherPathManagedTestSuite, DISABLED_ManagedModeReturns) {
     cipherPathManagedModeReturns(this);
 }
-
-// ============================================
-// ADDITIONAL EDGE CASE TESTS (NEW)
-// ============================================
 
 TEST_F(CipherPathTestSuite, MultipleConsecutiveWrongMoves) {
     cipherPathMultipleConsecutiveWrongMoves(this);
@@ -132,3 +187,4 @@ TEST_F(CipherPathTestSuite, ExitReachedAtBudgetLimit) {
 TEST_F(CipherPathTestSuite, WrongMoveAtBudgetLimit) {
     cipherPathWrongMoveAtBudgetLimit(this);
 }
+*/

--- a/test/test_cli/comprehensive-integration-reg-tests.cpp
+++ b/test/test_cli/comprehensive-integration-reg-tests.cpp
@@ -37,7 +37,9 @@ TEST_F(ComprehensiveIntegrationTestSuite, SignalEchoRapidButtonPresses) {
 // ============================================
 // GHOST RUNNER INTEGRATION TESTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#220) — Guitar Hero → Memory Maze
+// TODO(#220): Rewrite Ghost Runner integration tests for maze API
+/*
 TEST_F(ComprehensiveIntegrationTestSuite, GhostRunnerEasyWinUnlocksButton) {
         ghostRunnerEasyWinUnlocksButton(this);
 }
@@ -57,6 +59,7 @@ TEST_F(ComprehensiveIntegrationTestSuite, GhostRunnerBoundaryPress) {
 TEST_F(ComprehensiveIntegrationTestSuite, GhostRunnerRapidPresses) {
         ghostRunnerRapidPresses(this);
 }
+*/
 
 // ============================================
 // SPIKE VECTOR INTEGRATION TESTS
@@ -97,7 +100,9 @@ TEST_F(ComprehensiveIntegrationTestSuite, FirewallDecryptLossNoRewards) {
 // ============================================
 // CIPHER PATH INTEGRATION TESTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#242) — binary cipher → wire routing
+// TODO(#242): Rewrite Cipher Path integration tests for wire routing API
+/*
 TEST_F(ComprehensiveIntegrationTestSuite, CipherPathEasyWinUnlocksButton) {
     cipherPathEasyWinUnlocksButton(this);
 }
@@ -109,6 +114,7 @@ TEST_F(ComprehensiveIntegrationTestSuite, CipherPathHardWinUnlocksColorProfile) 
 TEST_F(ComprehensiveIntegrationTestSuite, CipherPathLossNoRewards) {
     cipherPathLossNoRewards(this);
 }
+*/
 
 // ============================================
 // EXPLOIT SEQUENCER INTEGRATION TESTS

--- a/test/test_cli/comprehensive-integration-tests.hpp
+++ b/test/test_cli/comprehensive-integration-tests.hpp
@@ -338,6 +338,11 @@ void signalEchoRapidButtonPresses(ComprehensiveIntegrationTestSuite* suite) {
 // ============================================
 // GHOST RUNNER INTEGRATION TESTS (GameType 1)
 // ============================================
+// NOTE: Ghost Runner tests temporarily disabled during Wave 18 redesign (#220)
+// Ghost Runner was redesigned from Guitar Hero rhythm to Memory Maze.
+// Tests need complete rewrite for maze navigation mechanics.
+// TODO(#220): Rewrite Ghost Runner integration tests for maze API
+#if 0
 
 /*
  * Test: Ghost Runner EASY win → unlocks START button
@@ -554,6 +559,8 @@ void ghostRunnerRapidPresses(ComprehensiveIntegrationTestSuite* suite) {
     int stateId = gr->getCurrentState()->getStateId();
     ASSERT_TRUE(stateId >= GHOST_INTRO && stateId <= GHOST_LOSE) << "Invalid state: " << stateId;
 }
+
+#endif // Ghost Runner tests disabled
 
 // ============================================
 // SPIKE VECTOR INTEGRATION TESTS (GameType 2)
@@ -890,6 +897,11 @@ void firewallDecryptLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
 // ============================================
 // CIPHER PATH INTEGRATION TESTS (GameType 4)
 // ============================================
+// NOTE: Cipher Path tests temporarily disabled during Wave 18 redesign (#242)
+// Cipher Path was redesigned from binary cipher to wire routing puzzle.
+// Tests need complete rewrite for tile rotation mechanics.
+// TODO(#242): Rewrite Cipher Path integration tests for wire routing API
+#if 0
 
 /*
  * Test: Cipher Path EASY win → unlocks RIGHT button
@@ -1041,6 +1053,8 @@ void cipherPathLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     // No progression
     ASSERT_EQ(suite->player_.player->getKonamiProgress(), progressBefore);
 }
+
+#endif // Cipher Path tests disabled
 
 // ============================================
 // EXPLOIT SEQUENCER INTEGRATION TESTS (GameType 5)

--- a/test/test_cli/demo-playtest-tests.cpp
+++ b/test/test_cli/demo-playtest-tests.cpp
@@ -21,7 +21,8 @@ TEST_F(DemoPlaytestSuite, SignalEchoHardPlaytest) {
 // ============================================
 // GHOST RUNNER PLAYTEST TESTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#220)
+/*
 TEST_F(DemoPlaytestSuite, GhostRunnerEasyPlaytest) {
     ghostRunnerEasyPlaytest(this);
 }
@@ -29,6 +30,7 @@ TEST_F(DemoPlaytestSuite, GhostRunnerEasyPlaytest) {
 TEST_F(DemoPlaytestSuite, GhostRunnerHardPlaytest) {
     ghostRunnerHardPlaytest(this);
 }
+*/
 
 // ============================================
 // SUMMARY TEST

--- a/test/test_cli/demo-playtest-tests.hpp
+++ b/test/test_cli/demo-playtest-tests.hpp
@@ -268,6 +268,9 @@ void signalEchoHardPlaytest(DemoPlaytestSuite* suite) {
 // ============================================
 // GHOST RUNNER PLAYTEST SIMULATIONS
 // ============================================
+// NOTE: Tests disabled during Wave 18 redesign (#220) — Guitar Hero → Memory Maze
+// TODO(#220): Rewrite Ghost Runner playtest for maze navigation mechanics
+#if 0
 
 /*
  * Ghost Runner Easy Mode Playtest
@@ -444,6 +447,8 @@ void ghostRunnerHardPlaytest(DemoPlaytestSuite* suite) {
     EXPECT_LE(avgAttempts, 10.0) << "Hard mode too hard (> 10 attempts)";
 }
 
+#endif // Ghost Runner playtest tests disabled
+
 // ============================================
 // SUMMARY PLAYTEST (ALL GAMES)
 // ============================================
@@ -466,8 +471,9 @@ void demoPlaytestSummary(DemoPlaytestSuite* suite) {
     // Run all game playtests
     signalEchoEasyPlaytest(suite);
     signalEchoHardPlaytest(suite);
-    ghostRunnerEasyPlaytest(suite);
-    ghostRunnerHardPlaytest(suite);
+    // Ghost Runner playtests disabled — Wave 18 redesign (#220) changed to maze
+    // ghostRunnerEasyPlaytest(suite);
+    // ghostRunnerHardPlaytest(suite);
 
     // Note: Other games (Spike Vector, Firewall Decrypt, Cipher Path,
     // Exploit Sequencer, Breach Defense) would have playtests added here

--- a/test/test_cli/e2e-game-suite-reg-tests.cpp
+++ b/test/test_cli/e2e-game-suite-reg-tests.cpp
@@ -9,10 +9,12 @@
 // ============================================
 // GHOST RUNNER E2E TESTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#220)
+/*
 TEST_F(E2EGameSuiteTestSuite, GhostRunnerEasyWin) {
     e2eGhostRunnerEasyWin(this);
 }
+*/
 
 // Note: Hard/Loss edge cases are covered in hard-mode-reencounter-tests.hpp
 // Basic hard win flow is tested in progression-e2e-tests.hpp
@@ -37,10 +39,12 @@ TEST_F(E2EGameSuiteTestSuite, SpikeVectorEasyWin) {
 // ============================================
 // CIPHER PATH E2E TESTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#242)
+/*
 TEST_F(E2EGameSuiteTestSuite, CipherPathEasyWin) {
     e2eCipherPathEasyWin(this);
 }
+*/
 
 // TEST_F(E2EGameSuiteTestSuite, CipherPathHardWin) {
 //     e2eCipherPathHardWin(this);

--- a/test/test_cli/e2e-game-suite-tests.hpp
+++ b/test/test_cli/e2e-game-suite-tests.hpp
@@ -117,6 +117,9 @@ public:
 // ============================================
 // GHOST RUNNER E2E TESTS
 // ============================================
+// NOTE: Tests disabled during Wave 18 redesign (#220) — Guitar Hero → Memory Maze
+// TODO(#220): Rewrite Ghost Runner E2E tests for maze API
+#if 0
 
 /*
  * Test: Ghost Runner EASY win → unlocks START button.
@@ -255,6 +258,8 @@ void e2eGhostRunnerLoss(E2EGameSuiteTestSuite* suite) {
     // No progression
     ASSERT_EQ(suite->player_.player->getKonamiProgress(), progressBefore);
 }
+
+#endif // Ghost Runner E2E tests disabled
 
 // ============================================
 // SPIKE VECTOR E2E TESTS
@@ -417,6 +422,9 @@ void e2eSpikeVectorLoss(E2EGameSuiteTestSuite* suite) {
 // ============================================
 // CIPHER PATH E2E TESTS
 // ============================================
+// NOTE: Tests disabled during Wave 18 redesign (#242) — binary cipher → wire routing
+// TODO(#242): Rewrite Cipher Path E2E tests for wire routing API
+#if 0
 
 /*
  * Test: Cipher Path EASY win → unlocks RIGHT button.
@@ -576,6 +584,8 @@ void e2eCipherPathLoss(E2EGameSuiteTestSuite* suite) {
     // No progression
     ASSERT_EQ(suite->player_.player->getKonamiProgress(), progressBefore);
 }
+
+#endif // Cipher Path E2E tests disabled
 
 // ============================================
 // EXPLOIT SEQUENCER E2E TESTS

--- a/test/test_cli/fdn-demo-scripts-reg-tests.cpp
+++ b/test/test_cli/fdn-demo-scripts-reg-tests.cpp
@@ -33,10 +33,12 @@ TEST_F(FdnDemoScriptTestSuite, SignalEchoRapidButtonSpam) {
 // ============================================
 // GHOST RUNNER DEMO SCRIPTS
 // ============================================
-
+// NOTE: Tests disabled during Wave 18 redesign (#220)
+/*
 TEST_F(FdnDemoScriptTestSuite, GhostRunnerEasyCompleteWalkthrough) {
     ghostRunnerEasyCompleteWalkthrough(this);
 }
+*/
 
 // ============================================
 // SPIKE VECTOR DEMO SCRIPTS

--- a/test/test_cli/fdn-demo-scripts.hpp
+++ b/test/test_cli/fdn-demo-scripts.hpp
@@ -314,6 +314,9 @@ void signalEchoHardCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
 // ============================================
 // GHOST RUNNER WALKTHROUGH (GameType 1)
 // ============================================
+// NOTE: Tests disabled during Wave 18 redesign (#220) — Guitar Hero → Memory Maze
+// TODO(#220): Rewrite Ghost Runner demo walkthrough for maze API
+#if 0
 
 /*
  * Demo Script: Ghost Runner Easy Mode - Complete Walkthrough
@@ -379,6 +382,8 @@ void ghostRunnerEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(60, 100);
     suite->assertPlayerState(IDLE, "Idle");
 }
+
+#endif // Ghost Runner demo tests disabled
 
 // ============================================
 // SPIKE VECTOR WALKTHROUGH (GameType 2)

--- a/test/test_cli/ghost-runner-reg-tests.cpp
+++ b/test/test_cli/ghost-runner-reg-tests.cpp
@@ -1,99 +1,166 @@
 //
 // Ghost Runner Tests — Registration file for Ghost Runner minigame
 //
+// NOTE: Tests temporarily disabled during Wave 18 redesign (#220)
+// Ghost Runner was redesigned from a Guitar Hero rhythm game to a Memory Maze.
+// The old API (currentPattern, Lane, NoteGrade, ghostSpeedMs, notesPerRound)
+// was completely replaced with a maze-based API (cursorRow/Col, walls[], solutionPath[]).
+// Tests need complete rewrite for the new maze navigation mechanics.
+//
+// TODO(#220): Rewrite tests for memory maze mechanics
 
 #include <gtest/gtest.h>
 
-#include "ghost-runner-tests.hpp"
+// Temporarily not including header since all gameplay tests disabled
+// #include "ghost-runner-tests.hpp"
+
+// Minimal includes for config tests only
+#include "game/ghost-runner/ghost-runner.hpp"
 
 // ============================================
-// GHOST RUNNER TESTS
+// GHOST RUNNER TESTS — TEMPORARILY DISABLED
 // ============================================
 
+// Minimal test suite for basic sanity checks
+class GhostRunnerTestSuite : public testing::Test {
+public:
+    void SetUp() override {}
+    void TearDown() override {}
+};
+
+// Config tests updated for new Memory Maze API
 TEST_F(GhostRunnerTestSuite, EasyConfigPresets) {
-        ghostRunnerEasyConfigPresets(this);
+    GhostRunnerConfig easy = GHOST_RUNNER_EASY;
+    ASSERT_EQ(easy.cols, 5);
+    ASSERT_EQ(easy.rows, 3);
+    ASSERT_EQ(easy.rounds, 4);
+    ASSERT_EQ(easy.lives, 3);
+    ASSERT_EQ(easy.previewMazeMs, 4000);
+    ASSERT_EQ(easy.previewTraceMs, 4000);
+    ASSERT_EQ(easy.bonkFlashMs, 1000);
+    ASSERT_EQ(easy.startRow, 0);
+    ASSERT_EQ(easy.startCol, 0);
+    ASSERT_EQ(easy.exitRow, 2);
+    ASSERT_EQ(easy.exitCol, 4);
 }
 
 TEST_F(GhostRunnerTestSuite, HardConfigPresets) {
-        ghostRunnerHardConfigPresets(this);
+    GhostRunnerConfig hard = GHOST_RUNNER_HARD;
+    ASSERT_EQ(hard.cols, 7);
+    ASSERT_EQ(hard.rows, 5);
+    ASSERT_EQ(hard.rounds, 6);
+    ASSERT_EQ(hard.lives, 1);
+    ASSERT_EQ(hard.previewMazeMs, 2500);
+    ASSERT_EQ(hard.previewTraceMs, 3000);
+    ASSERT_EQ(hard.bonkFlashMs, 500);
+    ASSERT_EQ(hard.exitRow, 4);
+    ASSERT_EQ(hard.exitCol, 6);
 }
 
+TEST_F(GhostRunnerTestSuite, SessionResetClearsState) {
+    GhostRunnerSession session;
+    session.cursorRow = 3;
+    session.cursorCol = 4;
+    session.stepsUsed = 10;
+    session.livesRemaining = 0;
+    session.score = 100;
+    session.bonkCount = 5;
+    session.currentRound = 3;
+    session.mazeFlashActive = true;
+
+    session.reset();
+
+    ASSERT_EQ(session.cursorRow, 0);
+    ASSERT_EQ(session.cursorCol, 0);
+    ASSERT_EQ(session.currentDirection, DIR_RIGHT);
+    ASSERT_EQ(session.stepsUsed, 0);
+    ASSERT_EQ(session.livesRemaining, 3);
+    ASSERT_EQ(session.score, 0);
+    ASSERT_EQ(session.bonkCount, 0);
+    ASSERT_EQ(session.currentRound, 0);
+    ASSERT_EQ(session.solutionLength, 0);
+    ASSERT_FALSE(session.mazeFlashActive);
+}
+
+// All gameplay tests disabled pending rewrite for maze mechanics
+/*
 TEST_F(GhostRunnerTestSuite, IntroSeedsRng) {
-        ghostRunnerIntroSeedsRng(this);
+    ghostRunnerIntroSeedsRng(this);
 }
 
 TEST_F(GhostRunnerTestSuite, IntroTransitionsToShow) {
-        ghostRunnerIntroTransitionsToShow(this);
+    ghostRunnerIntroTransitionsToShow(this);
 }
 
 TEST_F(GhostRunnerTestSuite, ShowDisplaysRoundInfo) {
-        ghostRunnerShowDisplaysRoundInfo(this);
+    ghostRunnerShowDisplaysRoundInfo(this);
 }
 
 TEST_F(GhostRunnerTestSuite, ShowTransitionsToGameplay) {
-        ghostRunnerShowTransitionsToGameplay(this);
+    ghostRunnerShowTransitionsToGameplay(this);
 }
 
 TEST_F(GhostRunnerTestSuite, GhostAdvancesWithTime) {
-        ghostRunnerGhostAdvancesWithTime(this);
+    ghostRunnerGhostAdvancesWithTime(this);
 }
 
 TEST_F(GhostRunnerTestSuite, CorrectPressInTargetZone) {
-        ghostRunnerCorrectPressInTargetZone(this);
+    ghostRunnerCorrectPressInTargetZone(this);
 }
 
 TEST_F(GhostRunnerTestSuite, IncorrectPressOutsideZone) {
-        ghostRunnerIncorrectPressOutsideZone(this);
+    ghostRunnerIncorrectPressOutsideZone(this);
 }
 
 TEST_F(GhostRunnerTestSuite, GhostTimeoutCountsStrike) {
-        ghostRunnerGhostTimeoutCountsStrike(this);
+    ghostRunnerGhostTimeoutCountsStrike(this);
 }
 
 TEST_F(GhostRunnerTestSuite, EvaluateRoutesToNextRound) {
-        ghostRunnerEvaluateRoutesToNextRound(this);
+    ghostRunnerEvaluateRoutesToNextRound(this);
 }
 
 TEST_F(GhostRunnerTestSuite, EvaluateRoutesToWin) {
-        ghostRunnerEvaluateRoutesToWin(this);
+    ghostRunnerEvaluateRoutesToWin(this);
 }
 
 TEST_F(GhostRunnerTestSuite, EvaluateRoutesToLose) {
-        ghostRunnerEvaluateRoutesToLose(this);
+    ghostRunnerEvaluateRoutesToLose(this);
 }
 
 TEST_F(GhostRunnerTestSuite, WinSetsOutcome) {
-        ghostRunnerWinSetsOutcome(this);
+    ghostRunnerWinSetsOutcome(this);
 }
 
 TEST_F(GhostRunnerTestSuite, LoseSetsOutcome) {
-        ghostRunnerLoseSetsOutcome(this);
+    ghostRunnerLoseSetsOutcome(this);
 }
 
 TEST_F(GhostRunnerTestSuite, StandaloneLoopsToIntro) {
-        ghostRunnerStandaloneLoopsToIntro(this);
+    ghostRunnerStandaloneLoopsToIntro(this);
 }
 
 TEST_F(GhostRunnerTestSuite, StateNamesResolve) {
-        ghostRunnerStateNamesResolve(this);
+    ghostRunnerStateNamesResolve(this);
 }
 
 TEST_F(GhostRunnerTestSuite, PressAtZoneStartBoundary) {
-        ghostRunnerPressAtZoneStartBoundary(this);
+    ghostRunnerPressAtZoneStartBoundary(this);
 }
 
 TEST_F(GhostRunnerTestSuite, PressAtZoneEndBoundary) {
-        ghostRunnerPressAtZoneEndBoundary(this);
+    ghostRunnerPressAtZoneEndBoundary(this);
 }
 
 TEST_F(GhostRunnerTestSuite, ExactStrikesEqualAllowed) {
-        ghostRunnerExactStrikesEqualAllowed(this);
+    ghostRunnerExactStrikesEqualAllowed(this);
 }
 
 TEST_F(GhostRunnerTestSuite, TimeoutAtExactMissesAllowed) {
-        ghostRunnerTimeoutAtExactMissesAllowed(this);
+    ghostRunnerTimeoutAtExactMissesAllowed(this);
 }
 
 TEST_F(GhostRunnerManagedTestSuite, ManagedModeReturns) {
-        ghostRunnerManagedModeReturns(this);
+    ghostRunnerManagedModeReturns(this);
 }
+*/


### PR DESCRIPTION
## Summary

- Fixes CLI test suite compile failure on main caused by Wave 18 batch merge
- Disables 61 tests across 10 files that reference APIs completely replaced by Ghost Runner (#264) and Cipher Path (#268) visual redesigns
- Adds 6 new tests for the updated Memory Maze and Wire Routing config/session APIs
- Follows the same disable pattern used for Breach Defense in Wave 18

## Changes

| File | Action |
|---|---|
| `ghost-runner-reg-tests.cpp` | Disable 21 old tests, add 3 new (config+session) |
| `cipher-path-reg-tests.cpp` | Disable 26 old tests, add 3 new (config+session) |
| `comprehensive-integration-tests.hpp` + reg | `#if 0` GR+CP functions (8 tests) |
| `e2e-game-suite-tests.hpp` + reg | `#if 0` GR+CP functions (2 tests) |
| `fdn-demo-scripts.hpp` + reg | `#if 0` GR walkthrough (1 test) |
| `demo-playtest-tests.hpp` + `.cpp` | `#if 0` GR playtests (3 tests) |

## Test Results

- **Core tests**: 275/275 PASSED
- **CLI tests**: 137/137 PASSED (pre-existing SIGSEGV at teardown, not introduced here)
- **Before this fix**: CLI tests did not compile at all

## Test plan

- [x] `pio test -e native` — 275/275 pass
- [x] `pio test -e native_cli_test` — 137/137 pass (compiles again)
- [x] Verified SIGSEGV is pre-existing (also occurs on unmodified main)
- [x] No config preset values changed — only test expectations updated to match new APIs

Fixes #284