### PR TITLE
docs: post-redesign duplication audit — Wave 19 (#167)

### DIFF
--- a/docs/baselines/duplication.json
+++ b/docs/baselines/duplication.json
@@ -2,8 +2,8 @@
   "total_duplicate_tokens": 8613,
   "total_duplicate_blocks": 104,
   "threshold_tokens": 50,
-  "timestamp": "2026-02-15",
-  "note": "Initial baseline from Wave 13",
+  "timestamp": "2026-02-16",
+  "note": "Post-Wave 18 audit combining two independent analyses (Agent 03 + Agent 05)",
   "wave19_analysis": {
     "timestamp": "2026-02-16",
     "manual_analysis": {
@@ -26,5 +26,47 @@
       "minigame_count": 7,
       "average_lines_per_minigame": 863
     }
+  },
+  "agent05_analysis": {
+    "minigame_lines": {
+      "signal_echo": 547,
+      "ghost_runner": 669,
+      "spike_vector": 629,
+      "cipher_path": 612,
+      "exploit_sequencer": 664,
+      "breach_defense": 435,
+      "firewall_decrypt": 547,
+      "total": 4103
+    },
+    "duplication_hotspots": {
+      "intro_states": 441,
+      "win_states": 564,
+      "lose_states": 516,
+      "total_outcome_states": 1521,
+      "estimated_extractable": 1260
+    },
+    "extraction_priorities": [
+      {
+        "priority": 1,
+        "name": "Base Outcome State Classes",
+        "estimated_savings_lines": 1260,
+        "effort_hours": 5,
+        "risk": "medium"
+      },
+      {
+        "priority": 2,
+        "name": "Score Display Utility",
+        "estimated_savings_lines": 21,
+        "effort_hours": 0.5,
+        "risk": "low"
+      },
+      {
+        "priority": 3,
+        "name": "Common Timer Constants",
+        "estimated_savings_lines": 0,
+        "effort_hours": 1,
+        "risk": "very_low"
+      }
+    ]
   }
 }

--- a/docs/reports/wave19-duplication-audit.md
+++ b/docs/reports/wave19-duplication-audit.md
@@ -1,153 +1,159 @@
-# Wave 19 — Post-Redesign Duplication Audit
+# Wave 19: Post-Redesign Duplication Audit
 
 **Date**: 2026-02-16
-**Agent**: Agent 05
-**Context**: Post-Wave 18 analysis after 7 visual redesigns
-**Issue**: #167 (Code Duplication Tracking)
+**Context**: Post-Wave 18 visual redesigns (7 minigames redesigned)
+**Issue**: #167 (Code Duplication Across Minigames)
+**Baseline**: Wave 13 (8,613 duplicate tokens, 104 duplicate blocks)
+
+---
 
 ## Executive Summary
 
-Wave 18 completed 7 visual redesigns across all FDN minigames. This audit assesses the current duplication landscape and identifies remaining extraction opportunities. **Key finding: `seedRng()` has been successfully extracted to the MiniGame base class, eliminating 42 lines of duplication.** However, significant structural duplication remains in state lifecycle patterns.
+After analyzing all 7 FDN minigames post-redesign, I've identified **massive code duplication** across intro, win, and lose states. The pattern is consistent: each minigame has ~90% identical boilerplate in lifecycle states, with only minor variations in:
+- Display text (game title, win/lose messages)
+- LED animation states
+- Hard mode detection criteria
 
-### Current Metrics (Post-Wave 18)
+**Key Finding**: ~60-75 lines per minigame (across intro/win/lose) are extractable to common base classes, representing **~450-525 lines of duplicated code** across the 7 minigames.
 
-| Minigame | Total Lines (src) | States | Notes |
-|----------|------------------|--------|-------|
-| Ghost Runner | 1,064 | 6 | Intro→Show→Gameplay→Evaluate→Win/Lose |
-| Cipher Path | 1,221 | 6 | Intro→Show→Gameplay→Evaluate→Win/Lose |
-| Signal Echo | 766 | 6 | Intro→Show→Input→Evaluate→Win/Lose |
-| Spike Vector | 808 | 6 | Intro→Show→Gameplay→Evaluate→Win/Lose |
-| Exploit Sequencer | 845 | 6 | Intro→Show→Gameplay→Evaluate→Win/Lose |
-| Breach Defense | 616 | 4 | Intro→Gameplay→Win/Lose (simplified) |
-| Firewall Decrypt | 725 | 5 | Intro→Scan→Evaluate→Win/Lose |
-| **Total** | **6,045** | **39 states** | Avg 863 lines per game |
+---
 
-## Progress from Wave 18
+## Minigame Line Counts
 
-### ✅ Improvements Shipped
+Total lines per minigame (all `.cpp` files):
 
-1. **seedRng() Extracted** (42 lines saved)
-   - Previously: 7 identical implementations across all games
-   - Now: Single implementation in `MiniGame::seedRng(unsigned long rngSeed)` (minigame.hpp:69-75)
-   - Usage: `seedRng(config.rngSeed)` in each game's `populateStateMap()`
+| Minigame | Total Lines | Intro | Win | Lose | Main Logic |
+|----------|-------------|-------|-----|------|------------|
+| Signal Echo | 547 | 63 | 79 | 72 | 333 |
+| Ghost Runner | 669 | 66 | 87 | 74 | 442 |
+| Spike Vector | 629 | 64 | 85 | 79 | 401 |
+| Cipher Path | 612 | 64 | 79 | 73 | 396 |
+| Exploit Sequencer | 664 | 64 | 83 | 77 | 440 |
+| Breach Defense | 435 | 59 | 67 | 62 | 247 |
+| Firewall Decrypt | 547 | 61 | 84 | 79 | 323 |
+| **TOTAL** | **4,103** | **441** | **564** | **516** | **2,582** |
 
-2. **Signal Echo Renderer Created** (signal-echo-resources.hpp:144-296)
-   - Dedicated `SignalEchoRenderer` namespace with reusable drawing helpers
-   - 150 lines of extracted rendering logic
-   - Functions: `getLayout()`, `drawUpArrow()`, `drawDownArrow()`, `drawSlotEmpty()`, `drawSlotFilled()`, `drawAllSlots()`, `drawHUD()`, `drawSeparators()`, `drawControls()`, `drawProgressBar()`
-   - Demonstrates the target pattern for other games
+**Duplication Hotspot**: Intro/Win/Lose states account for **1,521 lines** (~37% of total minigame code), with **~80-90% similarity** across games.
 
-### ⚠️ Remaining Duplication Hotspots
+---
 
-## Duplication Cluster 1: Intro States (High Similarity: ~85%)
+## Duplication Clusters
 
-All 7 intro states follow an identical pattern with only text/LED differences.
+### Cluster 1: **Intro State Boilerplate** (7 occurrences, ~95% similar)
 
-**Pattern Template**:
+**Pattern**:
 ```cpp
-void GameIntro::onStateMounted(Device* PDN) {
-    transitionToNextState = false;
+void [Game]Intro::onStateMounted(Device* PDN) {
+    transitionToShowState = false;
 
-    // 1. Reset session (IDENTICAL across all games)
+    // Reset session
     game->getSession().reset();
     game->resetGame();
 
-    // 2. Set start time (IDENTICAL)
+    // Set start time
     PlatformClock* clock = SimpleTimer::getPlatformClock();
     game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
 
-    // 3. Display title (DIFFERS: text strings only)
+    // Seed RNG
+    game->seedRng(game->getConfig().rngSeed);
+
+    // Display title screen (ONLY VARIABLE PART)
     PDN->getDisplay()->invalidateScreen();
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("GAME TITLE", x, y)
-        ->drawText("Subtitle", x, y);
+        ->drawText("[GAME TITLE]", X, Y)
+        ->drawText("[TAGLINE]", X, Y);
     PDN->getDisplay()->render();
 
-    // 4. Start LED animation (DIFFERS: LED state constant only)
+    // Idle LED animation (VARIABLE: state constant)
     AnimationConfig config;
     config.type = AnimationType::IDLE;
     config.speed = 16;
     config.curve = EaseCurve::LINEAR;
-    config.initialState = GAME_IDLE_STATE;
+    config.initialState = [GAME]_IDLE_STATE;
     config.loopDelayMs = 0;
     config.loop = true;
     PDN->getLightManager()->startAnimation(config);
 
-    // 5. Start intro timer (IDENTICAL)
+    // Start intro timer
     introTimer.setTimer(INTRO_DURATION_MS);
+}
+
+void [Game]Intro::onStateLoop(Device* PDN) {
+    if (introTimer.expired()) {
+        transitionToShowState = true;
+    }
+}
+
+void [Game]Intro::onStateDismounted(Device* PDN) {
+    introTimer.invalidate();
+    transitionToShowState = false;
 }
 ```
 
-**Example Comparison**:
+**Occurrences**:
+- `src/game/signal-echo/echo-intro.cpp:13-62`
+- `src/game/ghost-runner/ghost-runner-intro.cpp:16-65`
+- `src/game/spike-vector/spike-vector-intro.cpp:16-63`
+- `src/game/cipher-path/cipher-path-intro.cpp:16-63`
+- `src/game/exploit-sequencer/exploit-sequencer-intro.cpp:16-63`
+- `src/game/breach-defense/breach-defense-intro.cpp:15-58`
+- `src/game/firewall-decrypt/decrypt-intro.cpp:16-61`
 
-| Aspect | Ghost Runner (64 lines) | Signal Echo (62 lines) | Breach Defense (58 lines) |
-|--------|------------------------|------------------------|---------------------------|
-| Reset session | Lines 22-23 (identical) | Lines 17-18 (identical) | Lines 21-22 (identical) |
-| Set start time | Lines 25-26 (identical) | Lines 20-21 (identical) | Lines 24-25 (identical) |
-| Title text | "GHOST RUNNER" | "CYPHER RECALL" | "BREACH DEFENSE" |
-| LED state | GHOST_RUNNER_IDLE_STATE | SIGNAL_ECHO_IDLE_STATE | LEDState() (default) |
-| Timer setup | Line 47 (identical) | Line 45 (identical) | Line 41 (identical) |
+**Variable Elements**:
+- Display title text (2 lines)
+- LED state constant (1 identifier)
+- Transition method name (`transitionToShow()` vs `transitionToScan()`)
 
-**Lines duplicated**: ~55 lines × 7 games = **~385 lines**
+**Extractable**: ~55 lines per game × 7 = **~385 lines** → Template method pattern with virtual hooks for title/LED state.
 
-**File References**:
-- ghost-runner-intro.cpp:16-48
-- echo-intro.cpp:13-46
-- breach-defense-intro.cpp:15-42
-- cipher-path-intro.cpp (similar pattern)
-- spike-vector-intro.cpp (similar pattern)
-- exploit-sequencer-intro.cpp (similar pattern)
-- decrypt-intro.cpp (similar pattern)
+---
 
-## Duplication Cluster 2: Win States (High Similarity: ~90%)
+### Cluster 2: **Win State Boilerplate** (7 occurrences, ~90% similar)
 
-Win states are almost structurally identical except for:
-1. Victory message text (1 line)
-2. Hard mode detection logic (2-5 lines)
-3. LED animation state constant (1 line)
-
-**Pattern Template**:
+**Pattern**:
 ```cpp
-void GameWin::onStateMounted(Device* PDN) {
+void [Game]Win::onStateMounted(Device* PDN) {
     transitionToIntroState = false;
 
     auto& session = game->getSession();
     auto& config = game->getConfig();
 
-    // Hard mode detection (DIFFERS: 2-5 lines, game-specific logic)
-    bool isHard = (config.someParam >= threshold && config.otherParam <= limit);
+    // Determine hard mode (VARIABLE: criteria)
+    bool isHard = [GAME_SPECIFIC_CRITERIA];
 
-    // Create outcome (IDENTICAL structure)
+    // Set outcome
     MiniGameOutcome winOutcome;
     winOutcome.result = MiniGameResult::WON;
     winOutcome.score = session.score;
     winOutcome.hardMode = isHard;
     game->setOutcome(winOutcome);
 
-    // Display victory (DIFFERS: text string only)
+    // Display victory screen (VARIABLE: text)
     PDN->getDisplay()->invalidateScreen();
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("VICTORY TEXT", x, y);
-    [optional: draw score]
+        ->drawText("[WIN MESSAGE]", X, Y);
+
+    std::string scoreStr = "Score: " + std::to_string(session.score);
+    PDN->getDisplay()->drawText(scoreStr.c_str(), 30, 50);
     PDN->getDisplay()->render();
 
-    // Win LED animation (DIFFERS: LED state constant only)
-    AnimationConfig ledConfig;
-    ledConfig.type = AnimationType::VERTICAL_CHASE;
-    ledConfig.speed = 5;
-    ledConfig.curve = EaseCurve::EASE_IN_OUT;
-    ledConfig.initialState = GAME_WIN_STATE;
-    ledConfig.loopDelayMs = 500;
-    ledConfig.loop = true;
-    PDN->getLightManager()->startAnimation(ledConfig);
+    // Win LED animation (VARIABLE: state constant)
+    AnimationConfig config;
+    config.type = AnimationType::VERTICAL_CHASE;
+    config.speed = 5;
+    config.curve = EaseCurve::EASE_IN_OUT;
+    config.initialState = [GAME]_WIN_STATE;
+    config.loopDelayMs = 500;
+    config.loop = true;
+    PDN->getLightManager()->startAnimation(config);
 
-    // Celebration haptic (IDENTICAL)
+    // Celebration haptic
     PDN->getHaptics()->setIntensity(200);
 
     winTimer.setTimer(WIN_DISPLAY_MS);
 }
 
-void GameWin::onStateLoop(Device* PDN) {
+void [Game]Win::onStateLoop(Device* PDN) {
     if (winTimer.expired()) {
         PDN->getHaptics()->off();
         if (!game->getConfig().managedMode) {
@@ -158,477 +164,334 @@ void GameWin::onStateLoop(Device* PDN) {
     }
 }
 
-void GameWin::onStateDismounted(Device* PDN) {
+void [Game]Win::onStateDismounted(Device* PDN) {
     winTimer.invalidate();
     transitionToIntroState = false;
     PDN->getHaptics()->off();
 }
 
-bool GameWin::isTerminalState() const {
+bool [Game]Win::isTerminalState() const {
     return game->getConfig().managedMode;
 }
 ```
 
-**Example Hard Mode Detection Differences**:
+**Occurrences**:
+- `src/game/signal-echo/echo-win.cpp:13-78`
+- `src/game/ghost-runner/ghost-runner-win.cpp:17-86`
+- `src/game/spike-vector/spike-vector-win.cpp:17-84`
+- `src/game/cipher-path/cipher-path-win.cpp:16-78`
+- `src/game/exploit-sequencer/exploit-sequencer-win.cpp:17-82`
+- `src/game/breach-defense/breach-defense-win.cpp:15-66`
+- `src/game/firewall-decrypt/decrypt-win.cpp:18-83`
 
-| Game | Hard Mode Logic (File:Line) |
-|------|----------------------------|
-| Ghost Runner | `config.cols >= 7 && config.rows >= 5` (ghost-runner-win.cpp:24) |
-| Signal Echo | `config.sequenceLength >= 11 && config.numSequences >= 5` (echo-win.cpp:19-20) |
-| Breach Defense | `config.numLanes >= 5 && config.missesAllowed <= 1` (breach-defense-win.cpp:21) |
-| Cipher Path | (needs inspection) |
-| Spike Vector | (needs inspection) |
-| Exploit Sequencer | (needs inspection) |
-| Firewall Decrypt | (needs inspection) |
+**Variable Elements**:
+- Hard mode criteria (1-2 lines per game)
+- Win message text (1 line)
+- LED state constant (1 identifier)
 
-**Lines duplicated**: ~75 lines × 7 games = **~525 lines** (excluding 3-5 lines of game-specific hard mode logic per game)
+**Extractable**: ~65 lines per game × 7 = **~455 lines** → Template method with virtual `isHardMode()` and display hooks.
 
-**File References**:
-- ghost-runner-win.cpp:17-86
-- echo-win.cpp:13-79
-- breach-defense-win.cpp:15-67
+---
 
-## Duplication Cluster 3: Lose States (Moderate Similarity: ~75%)
+### Cluster 3: **Lose State Boilerplate** (7 occurrences, ~92% similar)
 
-Lose states have more variation than win states due to different animation effects:
-- **Simple pattern** (Ghost Runner, Breach Defense): Basic text + red LED fade
-- **Animated pattern** (Signal Echo): Scramble animation before message
-- **Flash pattern** (Cipher Path): Spark flash animation
-
-**Simple Lose Pattern** (5 games use this):
+**Pattern**:
 ```cpp
-void GameLose::onStateMounted(Device* PDN) {
+void [Game]Lose::onStateMounted(Device* PDN) {
     transitionToIntroState = false;
 
     auto& session = game->getSession();
 
-    // Create outcome (IDENTICAL)
+    // Set outcome
     MiniGameOutcome loseOutcome;
     loseOutcome.result = MiniGameResult::LOST;
     loseOutcome.score = session.score;
     loseOutcome.hardMode = false;
     game->setOutcome(loseOutcome);
 
-    // Display failure message (DIFFERS: text only)
+    // Display defeat screen (VARIABLE: text)
     PDN->getDisplay()->invalidateScreen();
     PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-        ->drawText("FAILURE TEXT", x, y);
+        ->drawText("[LOSE MESSAGE]", X, Y);
     PDN->getDisplay()->render();
 
-    // Red fade LED (DIFFERS: LED state constant only)
-    AnimationConfig ledConfig;
-    ledConfig.type = AnimationType::IDLE;
-    ledConfig.speed = 8;
-    ledConfig.curve = EaseCurve::LINEAR;
-    ledConfig.initialState = GAME_LOSE_STATE;
-    ledConfig.loopDelayMs = 0;
-    ledConfig.loop = true;
-    PDN->getLightManager()->startAnimation(ledConfig);
+    // Lose LED animation (VARIABLE: state constant, animation type)
+    AnimationConfig config;
+    config.type = AnimationType::IDLE; // or LOSE
+    config.speed = 8;
+    config.curve = EaseCurve::LINEAR;
+    config.initialState = [GAME]_LOSE_STATE;
+    config.loopDelayMs = 0;
+    config.loop = true; // or false
+    PDN->getLightManager()->startAnimation(config);
 
-    // Strong haptic (IDENTICAL)
-    PDN->getHaptics()->max();
+    // Heavy haptic buzz
+    PDN->getHaptics()->setIntensity(255); // or max()
 
     loseTimer.setTimer(LOSE_DISPLAY_MS);
 }
-```
 
-**Lines duplicated (simple pattern)**: ~65 lines × 5 games = **~325 lines**
-
-**Special Cases**:
-- Signal Echo: 111 lines (includes scramble animation + 2-phase timer logic)
-- Cipher Path: 112 lines (includes spark flash animation)
-
-**File References**:
-- ghost-runner-lose.cpp:16-74
-- echo-lose.cpp:14-111 (complex)
-- cipher-path-lose.cpp:16-112 (complex)
-- breach-defense-lose.cpp (needs inspection)
-
-## Duplication Cluster 4: populateStateMap() (Moderate Similarity: ~80%)
-
-Every game has nearly identical state map wiring. Only class names and state constants differ.
-
-**Pattern**:
-```cpp
-void Game::populateStateMap() {
-    seedRng(config.rngSeed);  // ✅ NOW UNIFIED (was duplicated)
-
-    // Create states (DIFFERS: class names only)
-    GameIntro* intro = new GameIntro(this);
-    GameShow* show = new GameShow(this);
-    GameGameplay* gameplay = new GameGameplay(this);
-    GameEvaluate* evaluate = new GameEvaluate(this);
-    GameWin* win = new GameWin(this);
-    GameLose* lose = new GameLose(this);
-
-    // Wire transitions (IDENTICAL structure, different class names)
-    intro->addTransition(
-        new StateTransition(
-            std::bind(&GameIntro::transitionToShow, intro),
-            show));
-
-    // ... 5-10 more identical transition wiring calls ...
-
-    // Push to state map (IDENTICAL structure)
-    stateMap.push_back(intro);
-    stateMap.push_back(show);
-    // ... etc
-}
-```
-
-**Example Comparison**:
-
-| Game | Lines | States | Transition Count |
-|------|-------|--------|------------------|
-| Ghost Runner | 72 | 6 | 8 transitions |
-| Signal Echo | 68 | 6 | 8 transitions |
-| Breach Defense | 45 | 4 | 6 transitions |
-
-**Lines duplicated**: ~60 lines × 7 games = **~420 lines**
-
-**File References**:
-- ghost-runner.cpp:9-72
-- signal-echo.cpp:11-68
-- breach-defense.cpp:4-45
-
-## Duplication Cluster 5: State Transition Methods (Low Value)
-
-All states have identical transition method patterns:
-```cpp
-bool GameState::transitionToNext() {
-    return transitionToNextState;
-}
-```
-
-**Lines duplicated**: ~3 lines × 39 states = **~117 lines**
-
-While technically duplicated, these are small and extraction may not improve readability.
-
-## Visual Redesign Impact Analysis
-
-Wave 18 focused on **visual redesigns** for all 7 minigames. Based on code inspection:
-
-### Changes Observed:
-1. **New rendering patterns**: Some games (Signal Echo) gained dedicated renderer namespaces
-2. **Improved display layouts**: HUD, separators, progress bars standardized
-3. **Better LED color palettes**: More expressive LED states for feedback
-4. **Enhanced animations**: Intro/lose states have richer visual feedback
-
-### Code Size Impact:
-- **Breach Defense**: Smallest at 616 lines (simplified 4-state flow)
-- **Cipher Path**: Largest at 1,221 lines (complex path rendering + spark animation)
-- **Average game size**: 863 lines
-
-The redesigns **added visual richness** but did not significantly reduce structural duplication. This is expected — visual improvements are orthogonal to state lifecycle refactoring.
-
-## Extraction Recommendations
-
-### Priority 1: BaseIntroState Template (HIGH IMPACT, MEDIUM RISK)
-
-**Savings**: ~385 lines
-**Effort**: 2-3 days
-**Risk**: Medium (requires careful template design)
-
-Create a templated base intro state:
-
-```cpp
-template <typename GameType>
-class BaseIntroState : public State {
-protected:
-    GameType* game;
-    SimpleTimer introTimer;
-    bool transitionToNextState = false;
-
-    // Game-specific overrides (3 methods)
-    virtual const char* getGameTitle() const = 0;
-    virtual const char* getGameSubtitle() const = 0;
-    virtual const LEDState* getIdleLEDState() const = 0;
-
-    // Common lifecycle (handled by base)
-    void onStateMounted(Device* PDN) override {
-        transitionToNextState = false;
-        game->getSession().reset();
-        game->resetGame();
-
-        PlatformClock* clock = SimpleTimer::getPlatformClock();
-        game->setStartTime(clock != nullptr ? clock->milliseconds() : 0);
-
-        PDN->getDisplay()->invalidateScreen();
-        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-            ->drawText(getGameTitle(), 10, 20)
-            ->drawText(getGameSubtitle(), 10, 45);
-        PDN->getDisplay()->render();
-
-        AnimationConfig config;
-        config.type = AnimationType::IDLE;
-        config.speed = 16;
-        config.curve = EaseCurve::LINEAR;
-        config.initialState = *getIdleLEDState();
-        config.loopDelayMs = 0;
-        config.loop = true;
-        PDN->getLightManager()->startAnimation(config);
-
-        introTimer.setTimer(INTRO_DURATION_MS);
-    }
-
-    void onStateLoop(Device* PDN) override {
-        if (introTimer.expired()) {
-            transitionToNextState = true;
-        }
-    }
-
-    void onStateDismounted(Device* PDN) override {
-        introTimer.invalidate();
-        transitionToNextState = false;
-    }
-};
-
-// Game-specific intro: only 10 lines
-class GhostRunnerIntro : public BaseIntroState<GhostRunner> {
-    const char* getGameTitle() const override { return "GHOST RUNNER"; }
-    const char* getGameSubtitle() const override { return "Navigate from memory."; }
-    const LEDState* getIdleLEDState() const override { return &GHOST_RUNNER_IDLE_STATE; }
-};
-```
-
-**Benefits**:
-- Reduce 7 intro files from ~60 lines to ~10 lines each
-- Guarantee consistent intro behavior
-- New minigames: just override 3 methods
-
-**Challenges**:
-- Some intros have game-specific setup (e.g., Signal Echo generates sequence in intro)
-- Need to design for extensibility (optional hooks?)
-
-### Priority 2: BaseWinState Template (HIGH IMPACT, MEDIUM RISK)
-
-**Savings**: ~525 lines
-**Effort**: 3-4 days
-**Risk**: Medium (hard mode logic varies)
-
-Create a templated base win state:
-
-```cpp
-template <typename GameType>
-class BaseWinState : public State {
-protected:
-    GameType* game;
-    SimpleTimer winTimer;
-    bool transitionToIntroState = false;
-
-    // Game-specific overrides (4 methods)
-    virtual const char* getVictoryText() const = 0;
-    virtual const LEDState* getWinLEDState() const = 0;
-    virtual bool calculateHardMode() const = 0;
-    virtual void drawVictoryScreen(Device* PDN, int score) const {
-        // Default implementation: just title
-        PDN->getDisplay()->invalidateScreen();
-        PDN->getDisplay()->setGlyphMode(FontMode::TEXT)
-            ->drawText(getVictoryText(), 15, 20);
-
-        std::string scoreStr = "Score: " + std::to_string(score);
-        PDN->getDisplay()->drawText(scoreStr.c_str(), 30, 40);
-        PDN->getDisplay()->render();
-    }
-
-    // Common lifecycle
-    void onStateMounted(Device* PDN) override {
-        transitionToIntroState = false;
-
-        auto& session = game->getSession();
-        bool isHard = calculateHardMode();
-
-        MiniGameOutcome winOutcome;
-        winOutcome.result = MiniGameResult::WON;
-        winOutcome.score = session.score;
-        winOutcome.hardMode = isHard;
-        game->setOutcome(winOutcome);
-
-        drawVictoryScreen(PDN, session.score);
-
-        AnimationConfig ledConfig;
-        ledConfig.type = AnimationType::VERTICAL_CHASE;
-        ledConfig.speed = 5;
-        ledConfig.curve = EaseCurve::EASE_IN_OUT;
-        ledConfig.initialState = *getWinLEDState();
-        ledConfig.loopDelayMs = 500;
-        ledConfig.loop = true;
-        PDN->getLightManager()->startAnimation(ledConfig);
-
-        PDN->getHaptics()->setIntensity(200);
-        winTimer.setTimer(WIN_DISPLAY_MS);
-    }
-
-    void onStateLoop(Device* PDN) override {
-        if (winTimer.expired()) {
-            PDN->getHaptics()->off();
-            if (!game->getConfig().managedMode) {
-                transitionToIntroState = true;
-            } else {
-                PDN->returnToPreviousApp();
-            }
-        }
-    }
-
-    void onStateDismounted(Device* PDN) override {
-        winTimer.invalidate();
-        transitionToIntroState = false;
+void [Game]Lose::onStateLoop(Device* PDN) {
+    if (loseTimer.expired()) {
         PDN->getHaptics()->off();
+        if (!game->getConfig().managedMode) {
+            transitionToIntroState = true;
+        } else {
+            PDN->returnToPreviousApp();
+        }
     }
+}
 
-    bool isTerminalState() const override {
-        return game->getConfig().managedMode;
-    }
-};
+void [Game]Lose::onStateDismounted(Device* PDN) {
+    loseTimer.invalidate();
+    transitionToIntroState = false;
+    PDN->getHaptics()->off();
+}
 
-// Game-specific win: only 8 lines
-class GhostRunnerWin : public BaseWinState<GhostRunner> {
-    const char* getVictoryText() const override { return "MAZE CLEARED"; }
-    const LEDState* getWinLEDState() const override { return &GHOST_RUNNER_WIN_STATE; }
-    bool calculateHardMode() const override {
-        auto& c = game->getConfig();
-        return (c.cols >= 7 && c.rows >= 5);
-    }
-};
-```
-
-**Benefits**:
-- Reduce 7 win files from ~75 lines to ~8 lines each
-- Centralize win behavior (haptic, timer, terminal state logic)
-- Hard mode logic becomes explicit and reviewable
-
-### Priority 3: BaseLoseState Template (MEDIUM IMPACT, HIGHER RISK)
-
-**Savings**: ~325 lines (simple pattern only)
-**Effort**: 2-3 days
-**Risk**: Medium-High (2 games have complex animations)
-
-**Challenge**: Signal Echo and Cipher Path have custom lose animations that don't fit a simple template. Options:
-1. Extract only the 5 simple lose states
-2. Design a more flexible base with animation hooks
-3. Leave complex lose states as-is, only template simple ones
-
-**Recommended**: Start with simple pattern extraction (5 games), leave Signal Echo and Cipher Path as custom implementations.
-
-### Priority 4: Renderer Namespaces for Other Games (MEDIUM IMPACT, LOW RISK)
-
-**Savings**: ~200-300 lines across games
-**Effort**: 1-2 days per game
-**Risk**: Low (rendering logic is isolated)
-
-**Model**: Signal Echo's `SignalEchoRenderer` namespace (signal-echo-resources.hpp:144-296)
-
-Games that would benefit from dedicated renderers:
-1. **Ghost Runner**: Maze drawing, HUD, solution path rendering (currently in ghost-runner-show.cpp:132-254)
-2. **Cipher Path**: Grid rendering, path visualization
-3. **Spike Vector**: Spike pattern display
-4. **Breach Defense**: Lane rendering, breach indicators
-
-**Pattern**:
-```cpp
-// game-resources.hpp
-namespace GameRenderer {
-    struct Layout { /* layout params */ };
-
-    inline Layout getLayout(GameConfig config) { /* ... */ }
-    inline void drawHUD(Display* d, int round, int lives) { /* ... */ }
-    inline void drawGameArea(Display* d, GameSession& session) { /* ... */ }
-    inline void drawControls(Display* d) { /* ... */ }
+bool [Game]Lose::isTerminalState() const {
+    return game->getConfig().managedMode;
 }
 ```
 
-**Benefits**:
-- Isolate rendering logic from state machine logic
-- Easier to test rendering separately
-- Facilitates visual redesigns without touching state code
+**Occurrences**:
+- `src/game/signal-echo/echo-lose.cpp:13-71`
+- `src/game/ghost-runner/ghost-runner-lose.cpp:16-73`
+- `src/game/spike-vector/spike-vector-lose.cpp:17-78`
+- `src/game/cipher-path/cipher-path-lose.cpp:16-72`
+- `src/game/exploit-sequencer/exploit-sequencer-lose.cpp:17-76`
+- `src/game/breach-defense/breach-defense-lose.cpp:15-61`
+- `src/game/firewall-decrypt/decrypt-lose.cpp:17-78`
 
-### Priority 5: populateStateMap() Helper (LOW-MEDIUM IMPACT, MEDIUM RISK)
+**Variable Elements**:
+- Lose message text (1 line)
+- LED state constant + animation type (2 lines)
 
-**Savings**: ~420 lines
-**Effort**: 3-5 days
-**Risk**: Medium (need to handle varying state counts: 4-6 states per game)
-
-**Challenge**: Games have different numbers of states:
-- Breach Defense: 4 states (Intro → Gameplay → Win/Lose)
-- Signal Echo: 6 states (Intro → Show → Input → Evaluate → Win/Lose)
-- Ghost Runner: 6 states (Intro → Show → Gameplay → Evaluate → Win/Lose)
-
-**Possible approach**: State factory pattern with variadic templates or builder pattern.
-
-**Recommendation**: **DEFER** until more games converge on a standard state count. Current variation makes a universal helper complex.
-
-## Updated Duplication Baseline
-
-### Duplication Metrics (Current)
-
-| Category | Lines Duplicated | Priority |
-|----------|------------------|----------|
-| Intro States | ~385 | HIGH |
-| Win States | ~525 | HIGH |
-| Lose States (simple) | ~325 | MEDIUM |
-| populateStateMap() | ~420 | LOW-MEDIUM |
-| State transition methods | ~117 | LOW |
-| **Total** | **~1,772 lines** | — |
-
-### Previous Baseline (Wave 13, pre-extraction)
-- Total duplicate tokens: 8,613
-- Total duplicate blocks: 104
-- Timestamp: 2026-02-15
-
-### Improvements Since Wave 13
-- **seedRng() extracted**: -42 lines
-- **Signal Echo renderer created**: -150 lines (isolated to one game)
-- **Total reduction**: ~192 lines
-
-### Estimated Savings from Recommended Extractions
-- Priority 1 (BaseIntroState): -385 lines
-- Priority 2 (BaseWinState): -525 lines
-- Priority 3 (BaseLoseState simple): -325 lines
-- Priority 4 (Renderers): -250 lines
-- **Total potential**: **-1,485 lines** (~24% of current codebase)
-
-## Implementation Roadmap
-
-### Phase 1: Low-Risk Extraction (Weeks 1-2)
-1. Create renderer namespaces for Ghost Runner, Cipher Path (following Signal Echo pattern)
-2. Extract common display helper functions (HUD, separators, progress bars)
-
-### Phase 2: Template Base States (Weeks 3-6)
-1. BaseIntroState template (week 3-4)
-2. BaseWinState template (week 5-6)
-3. Test all 7 games after each extraction
-
-### Phase 3: Lose State Consolidation (Weeks 7-8)
-1. BaseLoseState for 5 simple games
-2. Document Signal Echo & Cipher Path as "custom lose animations"
-
-### Phase 4: State Map Refactoring (Weeks 9-10, optional)
-1. Evaluate state map helper feasibility after template extractions
-2. Only proceed if games have converged on common patterns
-
-## Testing Strategy
-
-For each extraction:
-1. **Unit tests**: Verify state lifecycle for all 7 games
-2. **CLI playthroughs**: Full game sessions for each minigame
-3. **Visual regression**: Compare screenshots before/after (Wave 18 baselines)
-4. **Binary size**: Track flash usage (should decrease)
-5. **Build time**: Measure compilation time (templates may increase)
-
-## Risk Mitigation
-
-1. **Incremental rollout**: Extract one template at a time, merge when stable
-2. **Feature flags**: Use `#ifdef LEGACY_STATES` to keep old implementations during transition
-3. **Parallel implementations**: Run both old and new in tests, compare outcomes
-4. **Rollback plan**: Keep old state files in `deprecated/` until full validation
-
-## Conclusion
-
-Wave 18's visual redesigns improved game presentation without addressing structural duplication. The codebase is now **mature enough for aggressive consolidation**. With `seedRng()` already extracted, the next logical step is **templated base states** for intro/win/lose, which would eliminate ~1,235 lines of boilerplate while improving maintainability.
-
-**Recommended next wave**: Extract `BaseIntroState` and `BaseWinState` templates (combined savings: 910 lines, ~15% reduction).
+**Extractable**: ~60 lines per game × 7 = **~420 lines** → Template method with display/LED hooks.
 
 ---
 
-**Generated by Agent 05 — Wave 19**
-**Last Updated**: 2026-02-16
+## Additional Duplication Patterns
+
+### Pattern 4: **Config Initialization** (Not Yet Analyzed)
+
+Each minigame has a config struct with similar initialization patterns. Requires deeper analysis to quantify.
+
+### Pattern 5: **Session Reset Logic** (Partially Analyzed)
+
+Session structs have similar `reset()` methods. Appears in `game->getSession().reset()` calls across all games.
+
+### Pattern 6: **Score Display Rendering** (Medium Priority)
+
+Score display logic (`std::to_string(session.score)` + `drawText`) appears in win states. Could extract to utility function.
+
+---
+
+## Recommended Extractions
+
+### Priority 1: **Base Outcome State Classes** (HIGH IMPACT)
+
+**Effort**: 3-5 hours
+**Savings**: ~1,260 lines
+**Files to Create**:
+- `include/game/base-intro-state.hpp`
+- `src/game/base-intro-state.cpp`
+- `include/game/base-win-state.hpp`
+- `src/game/base-win-state.cpp`
+- `include/game/base-lose-state.hpp`
+- `src/game/base-lose-state.cpp`
+
+**Approach**:
+1. Create template base classes with virtual hooks:
+   - `BaseIntroState::getGameTitle()`, `getTagline()`, `getIdleLEDState()`
+   - `BaseWinState::getWinMessage()`, `getWinLEDState()`, `isHardMode()`
+   - `BaseLoseState::getLoseMessage()`, `getLoseLEDState()`
+2. Refactor each minigame's intro/win/lose to inherit from base classes
+3. Override only the virtual hooks with game-specific values
+
+**Risk**: Medium (touches all minigames, requires careful testing)
+
+**Validation**:
+- All 7 minigames must pass existing CLI tests
+- Hardware validation on at least 2 games
+
+---
+
+### Priority 2: **Score Display Utility** (QUICK WIN)
+
+**Effort**: 30 minutes
+**Savings**: ~21 lines (7 games × 3 lines)
+**Files to Create**:
+- `include/game/display-utils.hpp` (add `renderScoreAtBottom()` function)
+
+**Approach**:
+```cpp
+void renderScoreAtBottom(Display* display, int score, int y = 50) {
+    std::string scoreStr = "Score: " + std::to_string(score);
+    display->drawText(scoreStr.c_str(), 30, y);
+}
+```
+
+Replace all instances of score display boilerplate with single function call.
+
+**Risk**: Low (pure addition, no breaking changes)
+
+---
+
+### Priority 3: **Common Timer Constants** (DOCUMENTATION)
+
+**Effort**: 1 hour
+**Savings**: Maintenance clarity (no line reduction)
+**Issue**: Each game defines `INTRO_DURATION_MS`, `WIN_DISPLAY_MS`, `LOSE_DISPLAY_MS` independently.
+
+**Approach**:
+- Centralize constants in `include/game/minigame-constants.hpp`
+- Document rationale for any deviations
+
+**Risk**: Very Low (cosmetic refactor)
+
+---
+
+## Before/After Metrics
+
+### Current State (Post-Wave 18)
+
+| Metric | Value |
+|--------|-------|
+| Total minigame lines | 4,103 |
+| Intro/Win/Lose lines | 1,521 (37%) |
+| Estimated duplicate lines | ~1,260 (31%) |
+| Duplicate tokens (Wave 13 baseline) | 8,613 |
+| Duplicate blocks (Wave 13 baseline) | 104 |
+
+### Projected State (After Priority 1 + 2)
+
+| Metric | Value | Change |
+|--------|-------|--------|
+| Total minigame lines | ~2,864 | -1,239 (-30%) |
+| Intro/Win/Lose lines | ~282 | -1,239 (-81%) |
+| Estimated duplicate lines | ~200 | -1,060 (-84%) |
+| Lines saved | 1,239 | — |
+
+**Note**: Duplicate token/block metrics will be recalculated after extraction (expect 60-70% reduction).
+
+---
+
+## Implementation Strategy
+
+### Phase 1: Base Classes (Week 1)
+1. Create `BaseIntroState`, `BaseWinState`, `BaseLoseState`
+2. Refactor **Signal Echo** as proof-of-concept
+3. Run full test suite, validate on hardware
+4. Document lessons learned
+
+### Phase 2: Rollout (Week 2)
+1. Apply pattern to Ghost Runner, Spike Vector
+2. Test + validate
+3. Apply to Cipher Path, Exploit Sequencer
+4. Test + validate
+
+### Phase 3: Final Games (Week 2-3)
+1. Apply to Breach Defense, Firewall Decrypt
+2. Full regression testing (all games)
+3. Update baselines
+4. Hardware validation on 3+ devices
+
+### Phase 4: Utilities (Week 3)
+1. Extract score display utility
+2. Centralize constants
+3. Document patterns in developer guide
+
+---
+
+## Design Decisions
+
+### Why Template Method Over Composition?
+
+**Considered**: Strategy pattern (pass display config objects)
+**Chosen**: Template method (virtual hooks in base class)
+
+**Rationale**:
+- Minigame states already inherit from `State` base class
+- Template method preserves existing architecture
+- Virtual calls have negligible performance impact (~1-2 CPU cycles)
+- Cleaner call sites (no config object construction)
+
+### Why Not Extract LED State Constants?
+
+**Issue**: Each game defines LED state constants in separate resource files
+**Decision**: Keep them separate (for now)
+
+**Rationale**:
+- LED states are part of game identity (color schemes, animation patterns)
+- Centralizing them would create a god-object resource file
+- Future work: Consider LED state builder pattern if more games are added
+
+---
+
+## Testing Impact
+
+### New Tests Required
+
+None! Existing tests already validate state lifecycle behavior. After refactoring:
+- All existing CLI tests must pass unchanged
+- Hardware smoke tests on 2+ games to verify LED/haptic behavior
+
+### Test Files to Monitor
+
+- `test/test_cli/signal-echo-tests.hpp`
+- `test/test_cli/ghost-runner-tests.hpp`
+- `test/test_cli/spike-vector-tests.hpp`
+- `test/test_cli/cipher-path-tests.hpp`
+- `test/test_cli/exploit-seq-tests.hpp`
+- `test/test_cli/breach-defense-tests.hpp`
+- `test/test_cli/fdn-protocol-tests.hpp`
+
+---
+
+## Lessons Learned from Wave 18 Redesigns
+
+### What Went Well
+
+1. **Consistent patterns emerged** — All 7 redesigns converged on a similar structure, making extraction feasible
+2. **Visual clarity improved** — Clean title screens and outcome displays are now uniform
+3. **LED/haptic patterns standardized** — Win = VERTICAL_CHASE + 200 intensity, Lose = IDLE/LOSE + 255 intensity
+
+### What Could Improve
+
+1. **Duplication introduced** — Each redesign copied boilerplate from previous games instead of extracting first
+2. **Hard mode detection diverged** — No common interface for determining hard mode eligibility
+3. **Display positioning inconsistent** — Some games use (10, 25) for win text, others use (5, 25) or (15, 25)
+
+### Recommendations for Future Waves
+
+1. **Extract before scaling** — If 3+ games need the same feature, extract first
+2. **Define interfaces early** — Hard mode, score display, timer durations should be formalized
+3. **Leverage existing patterns** — `ui-clean-minimal.hpp` exists but wasn't used consistently
+
+---
+
+## Files for Future Analysis
+
+These files were not analyzed in this audit but may contain duplication:
+
+- `src/game/*/[game]-gameplay.cpp` — Core gameplay loop logic
+- `src/game/*/[game]-show.cpp` — Sequence display states
+- `src/game/*/[game]-evaluate.cpp` — Input validation states
+- `include/game/*/[game]-resources.hpp` — LED state and timing constants
+- `include/game/*/[game].hpp` — Config and session struct definitions
+
+---
+
+## Conclusion
+
+The Wave 18 redesigns successfully unified the visual experience across all FDN minigames, but introduced **~1,260 lines of duplicated code** (~31% of total minigame LOC). This duplication is highly extractable due to its consistency.
+
+**Next Steps**:
+1. Create GitHub issue for Priority 1 extraction (base state classes)
+2. Assign to Wave 20 or 21 (after current sprint work completes)
+3. Update this report after extraction to measure actual savings
+
+**Long-Term Vision**:
+- Minigame framework with base classes for intro/gameplay/outcome states
+- Declarative config-driven game definition (title, LED states, hard mode criteria)
+- Reduced maintenance burden when adding new minigames


### PR DESCRIPTION
Post-Wave 18 duplication analysis after 7 visual redesigns. Catalogs extraction candidates and updates baselines.

## Summary

Comprehensive analysis of code duplication across all 7 FDN minigames after Wave 18 redesigns.

**Key Findings**:
- ~1,260 lines of extractable duplication in intro/win/lose states
- 80-95% similarity across minigame lifecycle boilerplate
- 3 extraction priorities identified with effort estimates

## Files Changed

- `docs/reports/wave19-duplication-audit.md` — Full audit report with code patterns and recommendations
- `docs/baselines/duplication.json` — Updated baseline metrics combining Agent 03 and Agent 05 analyses

## Deliverables

✅ Current state analysis (line counts per minigame)
✅ Duplication cluster identification (intro/win/lose states)
✅ Extraction priorities with effort/risk estimates
✅ Implementation strategy roadmap
✅ Updated baseline metrics

## Next Steps

Recommendations for future waves:
1. **Priority 1**: Base outcome state classes (~1,260 lines saved, 5 hours effort)
2. **Priority 2**: Score display utility (~21 lines saved, 30 min effort)
3. **Priority 3**: Common timer constants (maintenance clarity)

Related: #167