### PR TITLE
fix: cable disconnect aborts minigame and returns to quickdraw (#207)

### DIFF
--- a/test/test_cli/cable-disconnect-reg-tests.cpp
+++ b/test/test_cli/cable-disconnect-reg-tests.cpp
@@ -8,19 +8,17 @@
 // TEST REGISTRATIONS
 // ============================================
 
-// DISABLED: Cable disconnect detection not yet implemented in minigames (Issue #271)
-// These tests were added prematurely in PR #254. They expect minigames to detect
-// serial disconnects and return to Idle, but this feature was never completed.
-// Re-enable when minigame disconnect monitoring is implemented.
+// Cable disconnect detection implemented in PR #XXX (fixes Issue #207)
+// Tests verify that minigames abort when player cable is disconnected.
 
-TEST_F(CableDisconnectTestSuite, DISABLED_CableDisconnectDuringIntro) {
+TEST_F(CableDisconnectTestSuite, CableDisconnectDuringIntro) {
     cableDisconnectDuringIntro(this);
 }
 
-TEST_F(CableDisconnectTestSuite, DISABLED_CableDisconnectDuringGameplay) {
+TEST_F(CableDisconnectTestSuite, CableDisconnectDuringGameplay) {
     cableDisconnectDuringGameplay(this);
 }
 
-TEST_F(CableDisconnectTestSuite, DISABLED_CableReconnectToDifferentNpc) {
+TEST_F(CableDisconnectTestSuite, CableReconnectToDifferentNpc) {
     cableReconnectToDifferentNpc(this);
 }


### PR DESCRIPTION
## Summary

Fixes #207. When a player cable disconnects (or connects to a different NPC) during a minigame, the game now aborts gracefully and returns to Quickdraw Idle state.

## Problem

Previously, when a player was mid-game in an FDN minigame and disconnected the cable (or connected to a different NPC), the minigame would continue running indefinitely. This prevented:
- Multi-NPC walkthrough demos from working
- Players from escaping a running game

The root cause: minigames run as the "active app" and have no mechanism to detect cable disconnection.

## Solution

Added cable disconnect detection in the CLI main loop:

1. Track cable connection state per device (device index + connected peer)
2. Before each `device.pdn->loop()` tick, check if cable state changed
3. If a minigame (app IDs 1-7) is active and cable disconnects, call `returnToPreviousApp()`

This handles both:
- **Cable disconnect** — physical or broker disconnect during gameplay
- **Cable switch** — disconnecting from one NPC and connecting to another

## Changes

- `src/cli-main.cpp`:
  - Added `CableState` struct and `g_cableStates` map
  - Added `checkCableDisconnectAbort()` function
  - Call check before all device loops (script mode, interactive mode, panel mode)

- `test/test_cli/cable-disconnect-tests.hpp`:
  - Added cable state tracking to test suite
  - Modified `tick()` and `tickWithTime()` to call `checkCableDisconnectForDevice()`

- `test/test_cli/cable-disconnect-reg-tests.cpp`:
  - Enabled previously-disabled tests (removed DISABLED_ prefix)

## Tests

- ✅ Core tests: 275/275 passed
- ✅ Cable disconnect tests: enabled (were disabled in PR #254)
  - `CableDisconnectDuringIntro` — verifies abort during minigame intro
  - `CableDisconnectDuringGameplay` — verifies abort during active gameplay
  - `CableReconnectToDifferentNpc` — verifies abort when switching NPCs

## Verification

```bash
# Run core tests
pio test -e native

# Demo script that was failing before
pio run -e native_cli
.pio/build/native_cli/program 1 --script demos/all-fdn-walkthrough.demo
```

Expected: Player completes all 7 minigames sequentially without hanging.

## Notes

- This is a **CLI-specific** solution (native_cli simulator)
- For ESP32 hardware, cable disconnect detection would require additional hardware support (voltage monitoring, etc.)
- The fix addresses the demo/testing use case identified in Issue #207