### PR TITLE
fix: resolve SIGSEGV in test teardown

### DIFF
--- a/include/state/state-machine.hpp
+++ b/include/state/state-machine.hpp
@@ -132,6 +132,14 @@ public:
         return currentState;
     }
 
+    /**
+     * Safely get the current state's ID, or -1 if currentState is null.
+     * Use this instead of getCurrentState()->getStateId() to avoid null dereference crashes.
+     */
+    int getCurrentStateId() {
+        return currentState ? currentState->getStateId() : -1;
+    }
+
     void onStateMounted(Device *PDN) override {
         initialize(PDN);
     }

--- a/test/test_cli/boon-awarded-tests.hpp
+++ b/test/test_cli/boon-awarded-tests.hpp
@@ -59,7 +59,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;

--- a/test/test_cli/breach-defense-tests.hpp
+++ b/test/test_cli/breach-defense-tests.hpp
@@ -92,7 +92,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     BreachDefense* getBreachDefense() {
@@ -162,13 +162,13 @@ void breachDefenseIntroTransitionsToShow(BreachDefenseTestSuite* suite) {
     // Use skipToState to mount Intro cleanly with the platform clock set
     suite->game_->skipToState(suite->device_.pdn, 0);
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_INTRO);
 
     // Advance past 2s intro timer
     suite->tickWithTime(25, 100);
 
     // Should have transitioned to Show (1500ms timer), not yet to Gameplay
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_SHOW);
 }
 
 /*
@@ -178,7 +178,7 @@ void breachDefenseShowDisplaysThreatInfo(BreachDefenseTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);  // Show is index 1
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_SHOW);
 }
 
 /*
@@ -187,12 +187,12 @@ void breachDefenseShowDisplaysThreatInfo(BreachDefenseTestSuite* suite) {
 void breachDefenseShowTransitionsToGameplay(BreachDefenseTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);  // Show
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_SHOW);
 
     // Advance past 1.5s show timer
     suite->tickWithTime(20, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_GAMEPLAY);
 }
 
 /*
@@ -310,7 +310,7 @@ void breachDefenseEvaluateRoutesToNextThreat(BreachDefenseTestSuite* suite) {
     // Wait for eval to complete and transition
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_SHOW);
 }
 
 /*
@@ -335,7 +335,7 @@ void breachDefenseEvaluateRoutesToWin(BreachDefenseTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_WIN);
 }
 
 /*
@@ -365,7 +365,7 @@ void breachDefenseEvaluateRoutesToLose(BreachDefenseTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_LOSE);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_LOSE);
 }
 
 /*
@@ -394,12 +394,12 @@ void breachDefenseLoseSetsOutcome(BreachDefenseTestSuite* suite) {
 void breachDefenseStandaloneLoopsToIntro(BreachDefenseTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 4);  // Win
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_WIN);
 
     // Advance past 3s win timer
     suite->tickWithTime(35, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), BREACH_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), BREACH_INTRO);
 }
 
 /*
@@ -454,7 +454,7 @@ void breachDefenseManagedModeReturns(BreachDefenseManagedTestSuite* suite) {
 
     // Should be in Gameplay by now (past intro 2s + show 1.5s = 3.5s, we advanced 4s)
     // The threat may or may not have arrived depending on exact timing
-    int stateId = bd->getCurrentState()->getStateId();
+    int stateId = bd->getCurrentStateId();
 
     // If still in Gameplay, force the threat through
     if (stateId == BREACH_GAMEPLAY) {
@@ -463,13 +463,13 @@ void breachDefenseManagedModeReturns(BreachDefenseManagedTestSuite* suite) {
     }
 
     // If in Evaluate, wait for eval timer
-    stateId = bd->getCurrentState()->getStateId();
+    stateId = bd->getCurrentStateId();
     if (stateId == BREACH_EVALUATE) {
         suite->tickWithTime(10, 100);  // Past 500ms eval timer
     }
 
     // Should be in Win now (or already past it)
-    stateId = bd->getCurrentState()->getStateId();
+    stateId = bd->getCurrentStateId();
     if (stateId == BREACH_WIN) {
         ASSERT_EQ(bd->getOutcome().result, MiniGameResult::WON);
         // Advance past win timer (3s)

--- a/test/test_cli/cable-disconnect-tests.hpp
+++ b/test/test_cli/cable-disconnect-tests.hpp
@@ -115,14 +115,14 @@ void cableDisconnectDuringIntro(CableDisconnectTestSuite* suite) {
     suite->tickWithTime(100, 100);
 
     // Player should be in Idle state
-    int playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    int playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, IDLE);
 
     // Initiate FDN handshake
     suite->tick(50);
 
     // Player should detect FDN and enter FdnDetected state
-    playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, FDN_DETECTED);
 
     // Complete handshake and launch minigame
@@ -139,7 +139,7 @@ void cableDisconnectDuringIntro(CableDisconnectTestSuite* suite) {
     suite->tickWithTime(200, 10);
 
     // After disconnect + ticks, player should return to Idle (not crash/hang)
-    playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, IDLE) << "Player should return to Idle after cable disconnect, not hang in minigame";
 }
 
@@ -153,14 +153,14 @@ void cableDisconnectDuringGameplay(CableDisconnectTestSuite* suite) {
     suite->tickWithTime(100, 100);
 
     // Player should be in Idle state
-    int playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    int playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, IDLE);
 
     // Initiate FDN handshake
     suite->tick(50);
 
     // Player should detect FDN and enter FdnDetected state
-    playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, FDN_DETECTED);
 
     // Complete handshake and launch minigame
@@ -180,7 +180,7 @@ void cableDisconnectDuringGameplay(CableDisconnectTestSuite* suite) {
     suite->tickWithTime(200, 10);
 
     // After disconnect + ticks, player should return to Idle (not crash/hang)
-    playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, IDLE) << "Player should return to Idle after cable disconnect during gameplay";
 }
 
@@ -217,7 +217,7 @@ void cableReconnectToDifferentNpc(CableDisconnectTestSuite* suite) {
     suite->tickWithTime(300, 10);
 
     // Player should return to Idle first
-    int playerState = suite->player_.pdn->getActiveApp()->getCurrentState()->getStateId();
+    int playerState = suite->player_.pdn->getActiveApp()->getCurrentStateId();
     ASSERT_EQ(playerState, IDLE) << "Player should return to Idle after disconnect before detecting new NPC";
 
     // Cleanup

--- a/test/test_cli/cipher-path-tests.hpp
+++ b/test/test_cli/cipher-path-tests.hpp
@@ -92,7 +92,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     CipherPath* getCipherPath() {
@@ -156,32 +156,32 @@ void cipherPathIntroResetsSession(CipherPathTestSuite* suite) {
  * Test: Intro transitions to Show after timer expires.
  */
 void cipherPathIntroTransitionsToShow(CipherPathTestSuite* suite) {
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_INTRO);
 
     // Advance past 2s intro timer (use generous buffer)
     suite->tickWithTime(30, 100);
 
     // After intro timer, should be in Show (or Gameplay if Show timer also expired)
-    int stateId = suite->game_->getCurrentState()->getStateId();
+    int stateId = suite->game_->getCurrentStateId();
     ASSERT_TRUE(stateId == CIPHER_SHOW || stateId == CIPHER_GAMEPLAY)
         << "Expected Show or Gameplay after intro, got " << stateId;
 
     // More robust: skip to Intro, advance with enough time for intro but not show
     suite->game_->skipToState(suite->device_.pdn, 0);
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_INTRO);
 
     // Advance in small increments, checking for transition
     for (int i = 0; i < 30; i++) {
         suite->device_.clockDriver->advance(100);
         suite->device_.pdn->loop();
-        if (suite->game_->getCurrentState()->getStateId() != CIPHER_INTRO) {
+        if (suite->game_->getCurrentStateId() != CIPHER_INTRO) {
             break;
         }
     }
 
     // First transition from Intro should be to Show
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
 }
 
 // ============================================
@@ -196,7 +196,7 @@ void cipherPathShowDisplaysRoundInfo(CipherPathTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
 }
 
 /*
@@ -228,12 +228,12 @@ void cipherPathShowTransitionsToGameplay(CipherPathTestSuite* suite) {
     // Skip to Show (index 1)
     suite->game_->skipToState(suite->device_.pdn, 1);
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
 
     // Advance past 1.5s show timer
     suite->tickWithTime(20, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_GAMEPLAY);
 }
 
 // ============================================
@@ -315,7 +315,7 @@ void cipherPathReachExitTriggersEvaluate(CipherPathTestSuite* suite) {
     suite->tick(2);
 
     // Evaluate routes through to Show (next round) since more rounds remain
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
 }
 
 /*
@@ -347,7 +347,7 @@ void cipherPathBudgetExhaustedTriggersEvaluate(CipherPathTestSuite* suite) {
     suite->tick(2);
 
     // Evaluate routes through to Lose since budget exhausted without reaching exit
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_LOSE);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_LOSE);
 }
 
 // ============================================
@@ -370,7 +370,7 @@ void cipherPathEvaluateRoutesToNextRound(CipherPathTestSuite* suite) {
     suite->tick(2);
 
     // Should route to Show for next round
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
     ASSERT_EQ(session.currentRound, 1);
 }
 
@@ -390,7 +390,7 @@ void cipherPathEvaluateRoutesToWin(CipherPathTestSuite* suite) {
     suite->tick(2);
 
     // Should route to Win
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_WIN);
 }
 
 /*
@@ -409,7 +409,7 @@ void cipherPathEvaluateRoutesToLose(CipherPathTestSuite* suite) {
     suite->tick(2);
 
     // Should route to Lose
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_LOSE);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_LOSE);
 }
 
 // ============================================
@@ -457,12 +457,12 @@ void cipherPathStandaloneLoopsToIntro(CipherPathTestSuite* suite) {
     // Skip to Win (index 4)
     suite->game_->skipToState(suite->device_.pdn, 4);
     suite->tick(1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_WIN);
 
     // Advance past win timer (3s)
     suite->tickWithTime(35, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), CIPHER_INTRO);
 }
 
 // ============================================
@@ -524,13 +524,13 @@ void cipherPathManagedModeReturns(CipherPathManagedTestSuite* suite) {
         }
 
         // Should be in Show state now
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
         // Advance past show timer (1.5s)
         suite->tickWithTime(20, 100);
 
         // Should be in Gameplay state
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_GAMEPLAY);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_GAMEPLAY);
 
         auto& sess = cp->getSession();
 
@@ -538,7 +538,7 @@ void cipherPathManagedModeReturns(CipherPathManagedTestSuite* suite) {
         // After each correct move, check if we're still in Gameplay.
         // When we reach the exit, the state transitions through Evaluate.
         for (int step = 0; step < config.gridSize; step++) {
-            if (cp->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+            if (cp->getCurrentStateId() != CIPHER_GAMEPLAY) {
                 break;
             }
             int correctDir = sess.cipher[sess.playerPosition];
@@ -554,7 +554,7 @@ void cipherPathManagedModeReturns(CipherPathManagedTestSuite* suite) {
     }
 
     // After last round, should be in Win
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_WIN);
     ASSERT_EQ(cp->getOutcome().result, MiniGameResult::WON);
 
     // Advance past win timer (3s) — managed mode returns to previous app
@@ -705,7 +705,7 @@ void cipherPathBudgetEqualsGridSize(CipherPathTestSuite* suite) {
     EXPECT_EQ(session.playerPosition, config.gridSize - 1);
     EXPECT_LE(session.movesUsed, config.moveBudget);
     suite->tick(3);
-    EXPECT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_WIN);
+    EXPECT_EQ(suite->game_->getCurrentStateId(), CIPHER_WIN);
 }
 
 /*
@@ -733,7 +733,7 @@ void cipherPathReachExitMidGame(CipherPathTestSuite* suite) {
     suite->tick(3);
 
     // Should transition through Evaluate to Show (next round)
-    EXPECT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_SHOW);
+    EXPECT_EQ(suite->game_->getCurrentStateId(), CIPHER_SHOW);
     EXPECT_EQ(session.currentRound, 2);
 }
 
@@ -781,7 +781,7 @@ void cipherPathHardModePerfectPlayRequired(CipherPathTestSuite* suite) {
         }
         suite->tick(2);
 
-        if (suite->game_->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+        if (suite->game_->getCurrentStateId() != CIPHER_GAMEPLAY) {
             break;
         }
     }
@@ -819,7 +819,7 @@ void cipherPathExitReachedAtBudgetLimit(CipherPathTestSuite* suite) {
     // Should win (exit reached takes precedence over budget exhaustion)
     EXPECT_EQ(session.playerPosition, config.gridSize - 1);
     EXPECT_EQ(session.movesUsed, config.moveBudget);
-    EXPECT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_WIN);
+    EXPECT_EQ(suite->game_->getCurrentStateId(), CIPHER_WIN);
 }
 
 /*
@@ -849,7 +849,7 @@ void cipherPathWrongMoveAtBudgetLimit(CipherPathTestSuite* suite) {
     // Should lose (budget exhausted without reaching exit)
     EXPECT_EQ(session.playerPosition, 0);
     EXPECT_EQ(session.movesUsed, config.moveBudget);
-    EXPECT_EQ(suite->game_->getCurrentState()->getStateId(), CIPHER_LOSE);
+    EXPECT_EQ(suite->game_->getCurrentStateId(), CIPHER_LOSE);
 }
 
 #endif // NATIVE_BUILD

--- a/test/test_cli/color-profile-tests.hpp
+++ b/test/test_cli/color-profile-tests.hpp
@@ -100,7 +100,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;
@@ -203,7 +203,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;
@@ -392,7 +392,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;
@@ -483,7 +483,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;

--- a/test/test_cli/comprehensive-integration-tests.hpp
+++ b/test/test_cli/comprehensive-integration-tests.hpp
@@ -84,7 +84,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     // Helper: trigger FDN handshake from Idle
@@ -174,7 +174,7 @@ void signalEchoEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite) {
     suite->tick(5);
 
     // Should be in Win
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_WIN);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_WIN);
 
     // Advance past win timer → FdnComplete
     suite->tickWithTime(35, 100);
@@ -229,7 +229,7 @@ void signalEchoHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* sui
     }
     suite->tick(5);
 
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_WIN);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -274,7 +274,7 @@ void signalEchoLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     suite->tick(5);
 
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_LOSE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -301,7 +301,7 @@ void signalEchoTimeoutEdgeCase(ComprehensiveIntegrationTestSuite* suite) {
 
     // Don't press any buttons, just wait for timeout (if implemented)
     // For now, just verify clean state
-    int stateId = se->getCurrentState()->getStateId();
+    int stateId = se->getCurrentStateId();
     ASSERT_TRUE(stateId == ECHO_PLAYER_INPUT || stateId == ECHO_LOSE || stateId == ECHO_WIN);
 }
 
@@ -331,7 +331,7 @@ void signalEchoRapidButtonPresses(ComprehensiveIntegrationTestSuite* suite) {
     suite->tick(5);
 
     // Game should handle gracefully (either ignore extras or count mistakes)
-    int stateId = se->getCurrentState()->getStateId();
+    int stateId = se->getCurrentStateId();
     ASSERT_TRUE(stateId == ECHO_PLAYER_INPUT || stateId == ECHO_LOSE || stateId == ECHO_WIN || stateId == ECHO_EVALUATE);
 }
 
@@ -380,7 +380,7 @@ void ghostRunnerEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite) {
 
     // Should transition to Evaluate then Win
     suite->tick(5);
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -432,7 +432,7 @@ void ghostRunnerHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* su
     suite->tick(10);
 
     // Should be in Win (100% PERFECT = passes hard mode requirement)
-    int stateId = gr->getCurrentState()->getStateId();
+    int stateId = gr->getCurrentStateId();
     if (stateId != GHOST_WIN) {
         // Debug: print actual state and stats
         std::cerr << "State: " << stateId << " P:" << session.perfectCount
@@ -483,7 +483,7 @@ void ghostRunnerLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     session.livesRemaining = 0;
 
     suite->tick(5);  // Let evaluate trigger
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_LOSE);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -525,7 +525,7 @@ void ghostRunnerBoundaryPress(ComprehensiveIntegrationTestSuite* suite) {
 
     // Should register as hit (boundaries are inclusive)
     suite->tick(5);
-    int stateId = gr->getCurrentState()->getStateId();
+    int stateId = gr->getCurrentStateId();
     ASSERT_TRUE(stateId == GHOST_WIN || stateId == GHOST_EVALUATE);
 }
 
@@ -556,7 +556,7 @@ void ghostRunnerRapidPresses(ComprehensiveIntegrationTestSuite* suite) {
     }
 
     // Should handle gracefully - game continues or ends cleanly
-    int stateId = gr->getCurrentState()->getStateId();
+    int stateId = gr->getCurrentStateId();
     ASSERT_TRUE(stateId >= GHOST_INTRO && stateId <= GHOST_LOSE) << "Invalid state: " << stateId;
 }
 
@@ -605,7 +605,7 @@ void spikeVectorEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite) {
     int speedMs = speedMsForLevel(sv->getConfig(), 0);
     suite->tickWithTime(160 / speedMs + 10, speedMs);
 
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -655,7 +655,7 @@ void spikeVectorHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* su
     int speedMs = speedMsForLevel(sv->getConfig(), 0);
     suite->tickWithTime(160 / speedMs + 10, speedMs);
 
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -704,7 +704,7 @@ void spikeVectorLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
 
     suite->tickWithTime(20, 50);
 
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_LOSE);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -739,7 +739,7 @@ void spikeVectorRapidCursorMovement(ComprehensiveIntegrationTestSuite* suite) {
     }
 
     // Should handle gracefully
-    int stateId = sv->getCurrentState()->getStateId();
+    int stateId = sv->getCurrentStateId();
     ASSERT_TRUE(stateId >= SPIKE_INTRO && stateId <= SPIKE_EVALUATE);
 }
 
@@ -787,7 +787,7 @@ void firewallDecryptEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suit
     suite->tickWithTime(10, 100);
 
     // Should be in Win
-    ASSERT_EQ(fd->getCurrentState()->getStateId(), DECRYPT_WIN);
+    ASSERT_EQ(fd->getCurrentStateId(), DECRYPT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -836,7 +836,7 @@ void firewallDecryptHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite
 
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(fd->getCurrentState()->getStateId(), DECRYPT_WIN);
+    ASSERT_EQ(fd->getCurrentStateId(), DECRYPT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -884,7 +884,7 @@ void firewallDecryptLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
 
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(fd->getCurrentState()->getStateId(), DECRYPT_LOSE);
+    ASSERT_EQ(fd->getCurrentStateId(), DECRYPT_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -923,14 +923,14 @@ void cipherPathEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite) {
 
     // Play through all rounds
     for (int round = 0; round < config.rounds; round++) {
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
         suite->tickWithTime(20, 100);
 
         // Make correct moves
         auto& sess = cp->getSession();
         for (int step = 0; step < config.gridSize; step++) {
-            if (cp->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+            if (cp->getCurrentStateId() != CIPHER_GAMEPLAY) {
                 break;
             }
             int correctDir = sess.cipher[sess.playerPosition];
@@ -943,7 +943,7 @@ void cipherPathEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite) {
         }
     }
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -977,13 +977,13 @@ void cipherPathHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* sui
 
     // Play through all rounds
     for (int round = 0; round < config.rounds; round++) {
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
         suite->tickWithTime(20, 100);
 
         auto& sess = cp->getSession();
         for (int step = 0; step < config.gridSize; step++) {
-            if (cp->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+            if (cp->getCurrentStateId() != CIPHER_GAMEPLAY) {
                 break;
             }
             int correctDir = sess.cipher[sess.playerPosition];
@@ -996,7 +996,7 @@ void cipherPathHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* sui
         }
     }
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -1027,7 +1027,7 @@ void cipherPathLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     // Advance past intro
     suite->tickWithTime(25, 100);
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
     suite->tickWithTime(20, 100);
 
@@ -1044,7 +1044,7 @@ void cipherPathLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
         suite->tick(2);
     }
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_LOSE);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -1092,7 +1092,7 @@ void exploitSequencerEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* sui
 
     suite->tickWithTime(5, 100);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -1137,7 +1137,7 @@ void exploitSequencerHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuit
 
     suite->tickWithTime(5, 100);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -1179,7 +1179,7 @@ void exploitSequencerLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     suite->tick(3);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_LOSE);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -1219,7 +1219,7 @@ void exploitSequencerExactMarkerPress(ComprehensiveIntegrationTestSuite* suite) 
     suite->tickWithTime(5, 100);
 
     // Should be a perfect hit → Win
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_WIN);
 }
 
 // ============================================
@@ -1261,7 +1261,7 @@ void breachDefenseEasyWinUnlocksButton(ComprehensiveIntegrationTestSuite* suite)
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -1305,7 +1305,7 @@ void breachDefenseHardWinUnlocksColorProfile(ComprehensiveIntegrationTestSuite* 
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -1353,7 +1353,7 @@ void breachDefenseLossNoRewards(ComprehensiveIntegrationTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_LOSE);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -1395,7 +1395,7 @@ void breachDefenseShieldMovementDuringThreat(ComprehensiveIntegrationTestSuite* 
     suite->tickWithTime(10, 100);
 
     // Should win
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_WIN);
 }
 
 #endif // Breach Defense tests disabled
@@ -1481,7 +1481,7 @@ void allGamesHandleZeroScore(ComprehensiveIntegrationTestSuite* suite) {
     suite->tickWithTime(50, 100);
 
     // Should handle zero score gracefully
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_LOSE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_LOSE);
     ASSERT_EQ(se->getOutcome().score, 0);
 }
 

--- a/test/test_cli/e2e-game-suite-tests.hpp
+++ b/test/test_cli/e2e-game-suite-tests.hpp
@@ -73,7 +73,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     // Helper: trigger FDN handshake from Idle
@@ -158,7 +158,7 @@ void e2eGhostRunnerEasyWin(E2EGameSuiteTestSuite* suite) {
 
     // Should be in Win
     suite->tick(5);
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_WIN);
     ASSERT_EQ(gr->getOutcome().result, MiniGameResult::WON);
 
     // Advance past win timer (3s) → returns to FdnComplete
@@ -206,7 +206,7 @@ void e2eGhostRunnerHardWin(E2EGameSuiteTestSuite* suite) {
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     suite->tickWithTime(5, 100);
 
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -249,7 +249,7 @@ void e2eGhostRunnerLoss(E2EGameSuiteTestSuite* suite) {
     suite->tickWithTime(5, 100);
 
     // Should be in Lose
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_LOSE);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -304,7 +304,7 @@ void e2eSpikeVectorEasyWin(E2EGameSuiteTestSuite* suite) {
     suite->tickWithTime(20, 50);
 
     // Should be in Win
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -357,7 +357,7 @@ void e2eSpikeVectorHardWin(E2EGameSuiteTestSuite* suite) {
     // Advance until wall arrives
     suite->tickWithTime(20, 50);
 
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -409,7 +409,7 @@ void e2eSpikeVectorLoss(E2EGameSuiteTestSuite* suite) {
     // Advance until wall arrives
     suite->tickWithTime(20, 50);
 
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_LOSE);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -447,7 +447,7 @@ void e2eCipherPathEasyWin(E2EGameSuiteTestSuite* suite) {
     // Play through all rounds
     for (int round = 0; round < config.rounds; round++) {
         // In Show
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
         // Advance past show timer
         suite->tickWithTime(20, 100);
@@ -455,7 +455,7 @@ void e2eCipherPathEasyWin(E2EGameSuiteTestSuite* suite) {
         // In Gameplay — make correct moves until exit
         auto& sess = cp->getSession();
         for (int step = 0; step < config.gridSize; step++) {
-            if (cp->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+            if (cp->getCurrentStateId() != CIPHER_GAMEPLAY) {
                 break;
             }
             int correctDir = sess.cipher[sess.playerPosition];
@@ -469,7 +469,7 @@ void e2eCipherPathEasyWin(E2EGameSuiteTestSuite* suite) {
     }
 
     // Should be in Win
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -504,7 +504,7 @@ void e2eCipherPathHardWin(E2EGameSuiteTestSuite* suite) {
 
     // Play through all rounds
     for (int round = 0; round < config.rounds; round++) {
-        ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+        ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
         // Advance past show timer
         suite->tickWithTime(20, 100);
@@ -512,7 +512,7 @@ void e2eCipherPathHardWin(E2EGameSuiteTestSuite* suite) {
         // Make correct moves
         auto& sess = cp->getSession();
         for (int step = 0; step < config.gridSize; step++) {
-            if (cp->getCurrentState()->getStateId() != CIPHER_GAMEPLAY) {
+            if (cp->getCurrentStateId() != CIPHER_GAMEPLAY) {
                 break;
             }
             int correctDir = sess.cipher[sess.playerPosition];
@@ -525,7 +525,7 @@ void e2eCipherPathHardWin(E2EGameSuiteTestSuite* suite) {
         }
     }
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_WIN);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -557,7 +557,7 @@ void e2eCipherPathLoss(E2EGameSuiteTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // In Show
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_SHOW);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_SHOW);
 
     // Advance past show timer
     suite->tickWithTime(20, 100);
@@ -575,7 +575,7 @@ void e2eCipherPathLoss(E2EGameSuiteTestSuite* suite) {
         suite->tick(2);
     }
 
-    ASSERT_EQ(cp->getCurrentState()->getStateId(), CIPHER_LOSE);
+    ASSERT_EQ(cp->getCurrentStateId(), CIPHER_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -624,7 +624,7 @@ void e2eExploitSequencerEasyWin(E2EGameSuiteTestSuite* suite) {
     // Wait for evaluate and transition
     suite->tickWithTime(5, 100);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -671,7 +671,7 @@ void e2eExploitSequencerHardWin(E2EGameSuiteTestSuite* suite) {
 
     suite->tickWithTime(5, 100);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_WIN);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -713,7 +713,7 @@ void e2eExploitSequencerLoss(E2EGameSuiteTestSuite* suite) {
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     suite->tick(3);
 
-    ASSERT_EQ(es->getCurrentState()->getStateId(), EXPLOIT_LOSE);
+    ASSERT_EQ(es->getCurrentStateId(), EXPLOIT_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);
@@ -761,7 +761,7 @@ void e2eBreachDefenseEasyWin(E2EGameSuiteTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -808,7 +808,7 @@ void e2eBreachDefenseHardWin(E2EGameSuiteTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_WIN);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_WIN);
 
     // Advance past win timer
     suite->tickWithTime(35, 100);
@@ -857,7 +857,7 @@ void e2eBreachDefenseLoss(E2EGameSuiteTestSuite* suite) {
     // Wait for eval timer
     suite->tickWithTime(10, 100);
 
-    ASSERT_EQ(bd->getCurrentState()->getStateId(), BREACH_LOSE);
+    ASSERT_EQ(bd->getCurrentStateId(), BREACH_LOSE);
 
     // Advance past lose timer
     suite->tickWithTime(35, 100);

--- a/test/test_cli/e2e-walkthrough-tests.cpp
+++ b/test/test_cli/e2e-walkthrough-tests.cpp
@@ -72,7 +72,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     // Helper: trigger FDN handshake from Idle

--- a/test/test_cli/edge-case-tests.hpp
+++ b/test/test_cli/edge-case-tests.hpp
@@ -113,7 +113,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     DeviceInstance player_;
@@ -625,7 +625,7 @@ void edgeCaseNpcBufferFloodOnConnect(FdnEdgeCaseTestSuite* suite) {
 
     // Track FDN detection events
     int fdnDetectionCount = 0;
-    auto initialStateId = player.game->getCurrentState()->getStateId();
+    auto initialStateId = player.game->getCurrentStateId();
 
     // Now connect the cable - this should clear buffered messages
     SerialCableBroker::getInstance().connect(0, 1);
@@ -637,7 +637,7 @@ void edgeCaseNpcBufferFloodOnConnect(FdnEdgeCaseTestSuite* suite) {
         fdn.pdn->loop();
 
         // Count FDN detections (state transitions from IDLE to FDN_DETECTED)
-        auto currentStateId = player.game->getCurrentState()->getStateId();
+        auto currentStateId = player.game->getCurrentStateId();
         if (currentStateId == FDN_DETECTED && initialStateId != FDN_DETECTED) {
             fdnDetectionCount++;
         }
@@ -688,7 +688,7 @@ void edgeCaseNpcBroadcastAfterConnect(FdnEdgeCaseTestSuite* suite) {
     }
 
     // Should have received at least one FDN message
-    ASSERT_EQ(player.game->getCurrentState()->getStateId(), FDN_DETECTED)
+    ASSERT_EQ(player.game->getCurrentStateId(), FDN_DETECTED)
         << "NPC not broadcasting after cable connect";
 
     // Cleanup
@@ -736,7 +736,7 @@ void edgeCaseNpcReconnectClearsBuffer(FdnEdgeCaseTestSuite* suite) {
 
     // Reconnect - should clear buffer again
     int fdnDetectionCount = 0;
-    auto initialStateId = player.game->getCurrentState()->getStateId();
+    auto initialStateId = player.game->getCurrentStateId();
 
     SerialCableBroker::getInstance().connect(0, 1);
     for (int i = 0; i < 10; i++) {
@@ -744,7 +744,7 @@ void edgeCaseNpcReconnectClearsBuffer(FdnEdgeCaseTestSuite* suite) {
         player.pdn->loop();
         fdn.pdn->loop();
 
-        auto currentStateId = player.game->getCurrentState()->getStateId();
+        auto currentStateId = player.game->getCurrentStateId();
         if (currentStateId == FDN_DETECTED && initialStateId != FDN_DETECTED) {
             fdnDetectionCount++;
         }
@@ -781,7 +781,7 @@ void edgeCaseDeviceDestructorDismountsActiveApp(EdgeCaseTestSuite* suite) {
     ASSERT_NE(device.game->getCurrentState(), nullptr);
 
     // Get the current state ID before destruction
-    int stateId = device.game->getCurrentState()->getStateId();
+    int stateId = device.game->getCurrentStateId();
     ASSERT_GE(stateId, 0);
 
     // Destroy the device - this should dismount the active app

--- a/test/test_cli/exploit-sequencer-tests.hpp
+++ b/test/test_cli/exploit-sequencer-tests.hpp
@@ -92,7 +92,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     ExploitSequencer* getExploitSequencer() {
@@ -164,12 +164,12 @@ void exploitSeqIntroTransitionsToShow(ExploitSequencerTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 0);
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), EXPLOIT_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), EXPLOIT_INTRO);
 
     // Advance past 2s intro timer
     suite->tickWithTime(30, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), EXPLOIT_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), EXPLOIT_SHOW);
 }
 
 // ============================================

--- a/test/test_cli/fdn-demo-scripts.hpp
+++ b/test/test_cli/fdn-demo-scripts.hpp
@@ -87,7 +87,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     // Helper: trigger FDN handshake from Idle
@@ -211,14 +211,14 @@ void signalEchoEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // STEP 6: Gameplay - show sequence
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
     se->getSession().currentSequence = {true, false};  // PRIMARY, SECONDARY
 
     // Wait for sequence display
     suite->tickWithTime(20, 100);
 
     // Player input phase
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_PLAYER_INPUT);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_PLAYER_INPUT);
 
     // Enter correct sequence: PRIMARY (true), SECONDARY (false)
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
@@ -227,7 +227,7 @@ void signalEchoEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tick(5);
 
     // STEP 7: Win state
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_WIN);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_WIN);
 
     // Advance past win timer → FdnComplete
     suite->tickWithTime(35, 100);
@@ -276,12 +276,12 @@ void signalEchoHardCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Gameplay
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
     se->getSession().currentSequence = {true, true, false};
     suite->tickWithTime(20, 100);
 
     // Player input - correct sequence
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_PLAYER_INPUT);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_PLAYER_INPUT);
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
     suite->tick(1);
     suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
@@ -290,7 +290,7 @@ void signalEchoHardCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tick(5);
 
     // Win
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_WIN);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_WIN);
     suite->tickWithTime(35, 100);
 
     // Should route to BoonAwarded (color profile reward)
@@ -350,7 +350,7 @@ void ghostRunnerEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Gameplay states: GHOST_PREVIEW_MAZE -> GHOST_PREVIEW_TRACE -> GHOST_GAMEPLAY
-    int stateId = gr->getCurrentState()->getStateId();
+    int stateId = gr->getCurrentStateId();
 
     // Wait through preview phases (maze + solution trace)
     suite->tickWithTime(50, 100);  // ~5 seconds for both previews
@@ -372,7 +372,7 @@ void ghostRunnerEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     suite->tick(5);
 
     // Should be in Win state
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_WIN);
 
     // Advance to FdnComplete
     suite->tickWithTime(35, 100);
@@ -443,7 +443,7 @@ void spikeVectorEasyCompleteWalkthrough(FdnDemoScriptTestSuite* suite) {
     }
 
     // Should be in Win state
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
 
     // Advance to FdnComplete
     suite->tickWithTime(35, 100);
@@ -514,17 +514,17 @@ void signalEchoLossNoRewards(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Gameplay - intentionally make mistake
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
     se->getSession().currentSequence = {true, true, false, true, false};
     suite->tickWithTime(20, 100);
 
     // Player input - wrong first input
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_PLAYER_INPUT);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_PLAYER_INPUT);
     suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);  // Wrong!
     suite->tick(5);
 
     // Should be in Loss state
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_LOSE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_LOSE);
 
     // Advance to FdnComplete
     suite->tickWithTime(35, 100);
@@ -563,17 +563,17 @@ void signalEchoMultipleErrorsLoss(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Show sequence
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
     se->getSession().currentSequence = {true, false, true};
     suite->tickWithTime(20, 100);
 
     // Player input phase - make one wrong input
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_PLAYER_INPUT);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_PLAYER_INPUT);
     suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);  // Wrong! Should be PRIMARY
     suite->tick(5);
 
     // Should be in Loss state immediately (0 mistakes allowed)
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_LOSE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_LOSE);
 
     // Verify no button unlock
     suite->assertButtonUnlocked(KonamiButton::UP, false);
@@ -603,12 +603,12 @@ void signalEchoRapidButtonSpam(FdnDemoScriptTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Show sequence
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
     se->getSession().currentSequence = {true, false};
     suite->tickWithTime(20, 100);
 
     // Player input - spam both buttons rapidly
-    ASSERT_EQ(se->getCurrentState()->getStateId(), ECHO_PLAYER_INPUT);
+    ASSERT_EQ(se->getCurrentStateId(), ECHO_PLAYER_INPUT);
     for (int i = 0; i < 20; i++) {
         suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
         suite->player_.secondaryButtonDriver->execCallback(ButtonInteraction::CLICK);
@@ -616,7 +616,7 @@ void signalEchoRapidButtonSpam(FdnDemoScriptTestSuite* suite) {
     }
 
     // Game should still be running or in loss state, not crashed
-    int stateId = se->getCurrentState()->getStateId();
+    int stateId = se->getCurrentStateId();
     ASSERT_TRUE(stateId == ECHO_PLAYER_INPUT || stateId == ECHO_LOSE || stateId == ECHO_WIN);
 }
 

--- a/test/test_cli/fdn-game-tests.hpp
+++ b/test/test_cli/fdn-game-tests.hpp
@@ -97,13 +97,13 @@ void fdnGameHandshakeTimeout(FdnGameTestSuite* suite) {
     suite->fdn_.serialOutDriver->injectInput("*smac" + std::string(TestConstants::TEST_MAC_DEFAULT) + "\r");
     suite->tick(3);
 
-    ASSERT_EQ(suite->fdn_.game->getCurrentState()->getStateId(), 1);  // NPC_HANDSHAKE
+    ASSERT_EQ(suite->fdn_.game->getCurrentStateId(), 1);  // NPC_HANDSHAKE
 
     // Advance past timeout
     suite->fdn_.clockDriver->advance(11000);
     suite->tick(3);
 
-    ASSERT_EQ(suite->fdn_.game->getCurrentState()->getStateId(), 0);  // NPC_IDLE
+    ASSERT_EQ(suite->fdn_.game->getCurrentStateId(), 0);  // NPC_IDLE
 }
 
 // Test: FdnGame tracks game type and reward

--- a/test/test_cli/fdn-integration-tests.hpp
+++ b/test/test_cli/fdn-integration-tests.hpp
@@ -78,11 +78,11 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     int getFdnStateId() {
-        return fdn_.game->getCurrentState()->getStateId();
+        return fdn_.game->getCurrentStateId();
     }
 
     void connectCable() {
@@ -156,7 +156,7 @@ void fdnIntegrationTransitionsToSignalEcho(FdnIntegrationTestSuite* suite) {
     // Check Signal Echo via getApp:
     auto* echo = suite->player_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID));
     ASSERT_NE(echo, nullptr);
-    int echoStateId = echo->getCurrentState()->getStateId();
+    int echoStateId = echo->getCurrentStateId();
     ASSERT_GE(echoStateId, ECHO_INTRO);
 }
 
@@ -348,14 +348,14 @@ void fdnCompleteTransitionsToIdleAfterTimer(FdnCompleteTestSuite* suite) {
     suite->tick(1);
 
     // Should be at FdnComplete
-    int stateId = suite->device_.game->getCurrentState()->getStateId();
+    int stateId = suite->device_.game->getCurrentStateId();
     ASSERT_EQ(stateId, FDN_COMPLETE);
 
     // Wait for display timer (3 seconds)
     suite->tickWithTime(20, 200);
 
     // Should have transitioned back to Idle
-    stateId = suite->device_.game->getCurrentState()->getStateId();
+    stateId = suite->device_.game->getCurrentStateId();
     ASSERT_EQ(stateId, IDLE);
 }
 
@@ -563,7 +563,7 @@ void appSwitchingQuickdrawActiveAtStart(AppSwitchingTestSuite* suite) {
     ASSERT_NE(suite->device_.game, nullptr);
 
     // Its current state should be in the Quickdraw range (0-22)
-    int stateId = suite->device_.game->getCurrentState()->getStateId();
+    int stateId = suite->device_.game->getCurrentStateId();
     ASSERT_LE(stateId, 22);
 }
 
@@ -575,14 +575,14 @@ void appSwitchingReturnToPrevious(AppSwitchingTestSuite* suite) {
 
     // Get the Signal Echo app and check it's in the Echo state range
     auto* echo = suite->device_.pdn->getApp(StateId(SIGNAL_ECHO_APP_ID));
-    int stateId = echo->getCurrentState()->getStateId();
+    int stateId = echo->getCurrentStateId();
     ASSERT_GE(stateId, ECHO_INTRO);
 
     // Return to previous (Quickdraw)
     suite->device_.pdn->returnToPreviousApp();
     suite->tick(1);
 
-    stateId = suite->device_.game->getCurrentState()->getStateId();
+    stateId = suite->device_.game->getCurrentStateId();
     ASSERT_LT(stateId, ECHO_INTRO);
 }
 

--- a/test/test_cli/firewall-decrypt-tests.hpp
+++ b/test/test_cli/firewall-decrypt-tests.hpp
@@ -128,7 +128,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     FirewallDecrypt* getGame() {
@@ -409,7 +409,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     FirewallDecrypt* getFirewallDecrypt() {
@@ -568,7 +568,7 @@ public:
 void decryptScanTimeoutSetsFlag(DecryptTimeoutTestSuite* suite) {
     suite->tick(1);
     suite->tickWithTime(5, 500);  // Advance to Scan
-    ASSERT_EQ(suite->getGame()->getCurrentState()->getStateId(), DECRYPT_SCAN);
+    ASSERT_EQ(suite->getGame()->getCurrentStateId(), DECRYPT_SCAN);
 
     auto& session = suite->getGame()->getSession();
     ASSERT_FALSE(session.timedOut);
@@ -577,21 +577,21 @@ void decryptScanTimeoutSetsFlag(DecryptTimeoutTestSuite* suite) {
     suite->tickWithTime(60, 100);
 
     // Should have transitioned to Evaluate
-    ASSERT_EQ(suite->getGame()->getCurrentState()->getStateId(), DECRYPT_EVALUATE);
+    ASSERT_EQ(suite->getGame()->getCurrentStateId(), DECRYPT_EVALUATE);
 }
 
 // Test: Timeout causes evaluate to route to lose
 void decryptTimeoutRoutesToLose(DecryptTimeoutTestSuite* suite) {
     suite->tick(1);
     suite->tickWithTime(5, 500);  // Advance to Scan
-    ASSERT_EQ(suite->getGame()->getCurrentState()->getStateId(), DECRYPT_SCAN);
+    ASSERT_EQ(suite->getGame()->getCurrentStateId(), DECRYPT_SCAN);
 
     // Advance past timeout
     suite->tickWithTime(60, 100);
 
     // After evaluate processes timeout, should be in lose state
     suite->tick(3);
-    ASSERT_EQ(suite->getGame()->getCurrentState()->getStateId(), DECRYPT_LOSE);
+    ASSERT_EQ(suite->getGame()->getCurrentStateId(), DECRYPT_LOSE);
 }
 
 // Test: Timeout sets outcome to LOST
@@ -608,7 +608,7 @@ void decryptTimeoutSetsLoseOutcome(DecryptTimeoutTestSuite* suite) {
 void decryptSelectionBeforeTimeout(DecryptTimeoutTestSuite* suite) {
     suite->tick(1);
     suite->tickWithTime(5, 500);
-    ASSERT_EQ(suite->getGame()->getCurrentState()->getStateId(), DECRYPT_SCAN);
+    ASSERT_EQ(suite->getGame()->getCurrentStateId(), DECRYPT_SCAN);
 
     auto& session = suite->getGame()->getSession();
 

--- a/test/test_cli/ghost-runner-tests.hpp
+++ b/test/test_cli/ghost-runner-tests.hpp
@@ -92,7 +92,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     GhostRunner* getGhostRunner() {
@@ -205,7 +205,7 @@ void ghostRunnerShowDisplaysRoundInfo(GhostRunnerTestSuite* suite) {
 void ghostRunnerShowTransitionsToGameplay(GhostRunnerTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);  // index 1 = Show
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), GHOST_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), GHOST_SHOW);
 
     // Advance past 1.5s show timer
     suite->tickWithTime(20, 100);
@@ -480,13 +480,13 @@ void ghostRunnerManagedModeReturns(GhostRunnerManagedTestSuite* suite) {
     suite->tickWithTime(25, 100);
 
     // Should be in Show state
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_SHOW);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_SHOW);
 
     // Advance past show timer (1.5s)
     suite->tickWithTime(20, 100);
 
     // Should be in Gameplay
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_GAMEPLAY);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_GAMEPLAY);
 
     // Move note into hit zone and press
     auto& session = gr->getSession();
@@ -499,7 +499,7 @@ void ghostRunnerManagedModeReturns(GhostRunnerManagedTestSuite* suite) {
 
     // Should be in Evaluate, then Win
     suite->tick(5);
-    ASSERT_EQ(gr->getCurrentState()->getStateId(), GHOST_WIN);
+    ASSERT_EQ(gr->getCurrentStateId(), GHOST_WIN);
     ASSERT_EQ(gr->getOutcome().result, MiniGameResult::WON);
 
     // Advance past win timer (3s)

--- a/test/test_cli/hard-mode-reencounter-tests.hpp
+++ b/test/test_cli/hard-mode-reencounter-tests.hpp
@@ -78,7 +78,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     SignalEcho* getSignalEcho() {

--- a/test/test_cli/integration-harness.hpp
+++ b/test/test_cli/integration-harness.hpp
@@ -263,7 +263,7 @@ public:
      */
     int getPlayerStateId(int playerIndex) {
         DeviceInstance& player = getPlayer(playerIndex);
-        return player.game->getCurrentState()->getStateId();
+        return player.game->getCurrentStateId();
     }
 
     /**
@@ -271,7 +271,7 @@ public:
      */
     int getNpcStateId(int npcIndex) {
         DeviceInstance& npc = getNpc(npcIndex);
-        return npc.game->getCurrentState()->getStateId();
+        return npc.game->getCurrentStateId();
     }
 
     /**

--- a/test/test_cli/konami-code-tests.hpp
+++ b/test/test_cli/konami-code-tests.hpp
@@ -97,7 +97,7 @@ void testKonamiCodeCorrectSequence(KonamiCodeTestSuite* suite) {
     suite->tick();
 
     // Verify we're in the right state
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), KONAMI_CODE_ENTRY);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), KONAMI_CODE_ENTRY);
 
     // The correct sequence: UP UP DOWN DOWN LEFT RIGHT LEFT RIGHT B A B A START
     // Button indices: 0 0 1 1 2 3 2 3 4 5 4 5 6
@@ -126,7 +126,7 @@ void testKonamiCodeCorrectSequence(KonamiCodeTestSuite* suite) {
 
     // After completing the sequence, we should transition to KonamiCodeAccepted
     suite->tick(5);
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), KONAMI_CODE_ACCEPTED);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), KONAMI_CODE_ACCEPTED);
 
     // Verify hard mode was unlocked
     EXPECT_TRUE(suite->player_->hasHardModeUnlocked());
@@ -160,7 +160,7 @@ void testKonamiCodeIncorrectInput(KonamiCodeTestSuite* suite) {
     suite->tick();
 
     // The state should still be KonamiCodeEntry, but position should reset to 0
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), KONAMI_CODE_ENTRY);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), KONAMI_CODE_ENTRY);
 }
 
 void testKonamiCodeTimeout(KonamiCodeTestSuite* suite) {
@@ -175,7 +175,7 @@ void testKonamiCodeTimeout(KonamiCodeTestSuite* suite) {
     suite->tickWithTime(1, 30100);
 
     // Should transition to GameOverReturnIdle
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), GAME_OVER_RETURN_IDLE);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), GAME_OVER_RETURN_IDLE);
 }
 
 void testKonamiCodeRejectedNoButtons(KonamiCodeTestSuite* suite) {
@@ -186,13 +186,13 @@ void testKonamiCodeRejectedNoButtons(KonamiCodeTestSuite* suite) {
     suite->tick();
 
     // Verify we're in the right state
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), KONAMI_CODE_REJECTED);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), KONAMI_CODE_REJECTED);
 
     // Wait for display timeout (4 seconds)
     suite->tickWithTime(5, 1000);
 
     // Should transition back to Idle
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), IDLE);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), IDLE);
 }
 
 void testKonamiCodeAcceptedStateTransition(KonamiCodeTestSuite* suite) {
@@ -204,7 +204,7 @@ void testKonamiCodeAcceptedStateTransition(KonamiCodeTestSuite* suite) {
     suite->tick();
 
     // Verify we're in the right state
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), KONAMI_CODE_ACCEPTED);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), KONAMI_CODE_ACCEPTED);
 
     // Verify hard mode gets unlocked
     EXPECT_TRUE(suite->player_->hasHardModeUnlocked());
@@ -213,7 +213,7 @@ void testKonamiCodeAcceptedStateTransition(KonamiCodeTestSuite* suite) {
     suite->tickWithTime(6, 1000);
 
     // Should transition back to Idle
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), IDLE);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), IDLE);
 }
 
 void testGameOverReturnIdleTransition(KonamiCodeTestSuite* suite) {
@@ -222,13 +222,13 @@ void testGameOverReturnIdleTransition(KonamiCodeTestSuite* suite) {
     suite->tick();
 
     // Verify we're in the right state
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), GAME_OVER_RETURN_IDLE);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), GAME_OVER_RETURN_IDLE);
 
     // Wait for display timeout (2 seconds)
     suite->tickWithTime(3, 1000);
 
     // Should transition back to Idle
-    EXPECT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), IDLE);
+    EXPECT_EQ(suite->quickdraw_->getCurrentStateId(), IDLE);
 }
 
 void testHardModeUnlockPersistence(KonamiCodeTestSuite* suite) {

--- a/test/test_cli/konami-puzzle-tests.hpp
+++ b/test/test_cli/konami-puzzle-tests.hpp
@@ -88,7 +88,7 @@ void konamiPuzzleRoutingWithAllButtons(KonamiPuzzleTestSuite* suite) {
     suite->device_.serialOutDriver->injectInput("*fdn:7:6\r");
     suite->tick(3);
 
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), FDN_DETECTED);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), FDN_DETECTED);
 
     // Simulate handshake (send fack)
     suite->device_.serialOutDriver->injectInput("*fack\r");
@@ -114,7 +114,7 @@ void konamiPuzzleNoRoutingWithoutAllButtons(KonamiPuzzleTestSuite* suite) {
     suite->device_.serialOutDriver->injectInput("*fdn:7:6\r");
     suite->tick(3);
 
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), FDN_DETECTED);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), FDN_DETECTED);
 
     // Simulate handshake
     suite->device_.serialOutDriver->injectInput("*fack\r");

--- a/test/test_cli/native-driver-tests.hpp
+++ b/test/test_cli/native-driver-tests.hpp
@@ -979,7 +979,7 @@ void cliCommandRebootFromLaterState(CliCommandTestSuite* suite) {
     for (int i = 0; i < 10; i++) {
         suite->device_.pdn->loop();
     }
-    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), WELCOME_MESSAGE);
+    ASSERT_EQ(suite->device_.game->getCurrentStateId(), WELCOME_MESSAGE);
 
     // Reboot
     suite->device_.httpClientDriver->setMockServerEnabled(true);
@@ -988,13 +988,13 @@ void cliCommandRebootFromLaterState(CliCommandTestSuite* suite) {
     suite->device_.lastStateId = -1;
     suite->device_.game->skipToState(suite->device_.pdn, 1);
 
-    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), FETCH_USER_DATA);
+    ASSERT_EQ(suite->device_.game->getCurrentStateId(), FETCH_USER_DATA);
 
     // Run loops again — should transition to WelcomeMessage again
     for (int i = 0; i < 10; i++) {
         suite->device_.pdn->loop();
     }
-    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), WELCOME_MESSAGE);
+    ASSERT_EQ(suite->device_.game->getCurrentStateId(), WELCOME_MESSAGE);
 }
 
 // ============================================
@@ -1136,5 +1136,5 @@ void cliCommandRebootClearsHistory(CliCommandTestSuite* suite) {
     ASSERT_EQ(suite->device_.lastStateId, -1);
 
     // Device should be at FetchUserData
-    ASSERT_EQ(suite->device_.game->getCurrentState()->getStateId(), FETCH_USER_DATA);
+    ASSERT_EQ(suite->device_.game->getCurrentStateId(), FETCH_USER_DATA);
 }

--- a/test/test_cli/negative-flow-tests.hpp
+++ b/test/test_cli/negative-flow-tests.hpp
@@ -74,7 +74,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return hunter_.game->getCurrentState()->getStateId();
+        return hunter_.game->getCurrentStateId();
     }
 
     SignalEcho* getSignalEcho() {
@@ -164,7 +164,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return bounty_.game->getCurrentState()->getStateId();
+        return bounty_.game->getCurrentStateId();
     }
 
     SignalEcho* getSignalEcho() {

--- a/test/test_cli/progression-core-tests.hpp
+++ b/test/test_cli/progression-core-tests.hpp
@@ -66,7 +66,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     SignalEcho* getSignalEcho() {

--- a/test/test_cli/progression-e2e-tests.hpp
+++ b/test/test_cli/progression-e2e-tests.hpp
@@ -73,7 +73,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     SignalEcho* getSignalEcho() {

--- a/test/test_cli/signal-echo-tests.hpp
+++ b/test/test_cli/signal-echo-tests.hpp
@@ -640,7 +640,7 @@ void echoOneWrongArrowLoses(SignalEchoTestSuite* suite) {
 
 // Test: Button press during Intro state is ignored
 void echoButtonPressDuringIntroIgnored(SignalEchoTestSuite* suite) {
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), ECHO_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), ECHO_INTRO);
 
     auto& session = suite->game_->getSession();
     session.inputIndex = 0;
@@ -654,13 +654,13 @@ void echoButtonPressDuringIntroIgnored(SignalEchoTestSuite* suite) {
     // Session should be unchanged
     ASSERT_EQ(session.inputIndex, 0);
     ASSERT_EQ(static_cast<int>(session.playerInput.size()), 0);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), ECHO_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), ECHO_INTRO);
 }
 
 // Test: Button press during ShowSequence state is ignored
 void echoButtonPressDuringShowIgnored(SignalEchoTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
 
     auto& session = suite->game_->getSession();
     int initialIndex = session.inputIndex;

--- a/test/test_cli/spike-vector-tests.hpp
+++ b/test/test_cli/spike-vector-tests.hpp
@@ -97,7 +97,7 @@ public:
     }
 
     int getPlayerStateId() {
-        return player_.game->getCurrentState()->getStateId();
+        return player_.game->getCurrentStateId();
     }
 
     SpikeVector* getSpikeVector() {
@@ -180,12 +180,12 @@ void spikeVectorIntroResetsSession(SpikeVectorTestSuite* suite) {
  * Test: Intro timer transitions to Show state.
  */
 void spikeVectorIntroTransitionsToShow(SpikeVectorTestSuite* suite) {
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_INTRO);
 
     // Advance past 2s intro timer
     suite->tickWithTime(25, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_SHOW);
 }
 
 /*
@@ -196,7 +196,7 @@ void spikeVectorShowGeneratesGaps(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);
     suite->device_.pdn->loop();
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_SHOW);
 
     auto& session = suite->game_->getSession();
     auto& config = suite->game_->getConfig();
@@ -219,12 +219,12 @@ void spikeVectorShowTransitionsToGameplay(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 1);
     suite->device_.pdn->loop();
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_SHOW);
 
     // Advance past 1000ms show timer
     suite->tickWithTime(15, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_GAMEPLAY);
 }
 
 /*
@@ -235,7 +235,7 @@ void spikeVectorFormationAdvances(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 2);
     suite->device_.pdn->loop();
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_GAMEPLAY);
 
     auto& session = suite->game_->getSession();
     int initialX = session.formationX;
@@ -266,7 +266,7 @@ void spikeVectorCorrectDodge(SpikeVectorTestSuite* suite) {
 
     // Advance past show timer to gameplay
     suite->tickWithTime(15, 100);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_GAMEPLAY);
 
     // Move cursor to match gap position using button presses
     while (session.cursorPosition > firstGap) {
@@ -308,7 +308,7 @@ void spikeVectorMissedDodge(SpikeVectorTestSuite* suite) {
 
     // Advance past show timer to gameplay
     suite->tickWithTime(15, 100);
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_GAMEPLAY);
 
     // Move cursor to a position that is NOT the gap
     int wrongPos = (firstGap + 1) % config.numPositions;
@@ -343,7 +343,7 @@ void spikeVectorFormationCompleteTransition(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 2);
     suite->device_.pdn->loop();
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_GAMEPLAY);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_GAMEPLAY);
 
     // Advance enough time for all walls to pass off-screen
     // formationX starts at 128, needs to reach ~-26 (2 walls * 20 + 6)
@@ -351,7 +351,7 @@ void spikeVectorFormationCompleteTransition(SpikeVectorTestSuite* suite) {
     suite->tickWithTime(160 / speedMs + 10, speedMs);
 
     // Should have transitioned to Evaluate or beyond
-    int stateId = suite->game_->getCurrentState()->getStateId();
+    int stateId = suite->game_->getCurrentStateId();
     ASSERT_NE(stateId, SPIKE_GAMEPLAY);
 }
 
@@ -373,7 +373,7 @@ void spikeVectorEvaluateRoutesToNextLevel(SpikeVectorTestSuite* suite) {
     // Evaluate should route to Show for the next level
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_SHOW);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_SHOW);
 }
 
 /*
@@ -392,7 +392,7 @@ void spikeVectorEvaluateRoutesToWin(SpikeVectorTestSuite* suite) {
     suite->device_.pdn->loop();
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_WIN);
 }
 
 /*
@@ -411,7 +411,7 @@ void spikeVectorEvaluateRoutesToLose(SpikeVectorTestSuite* suite) {
     suite->device_.pdn->loop();
     suite->tick(1);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_LOSE);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_LOSE);
 }
 
 /*
@@ -454,12 +454,12 @@ void spikeVectorStandaloneLoopsToIntro(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 4);
     suite->device_.pdn->loop();
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_WIN);
 
     // Advance past win timer (3s)
     suite->tickWithTime(35, 100);
 
-    ASSERT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_INTRO);
+    ASSERT_EQ(suite->game_->getCurrentStateId(), SPIKE_INTRO);
 }
 
 /*
@@ -507,7 +507,7 @@ void spikeVectorManagedModeReturns(SpikeVectorManagedTestSuite* suite) {
     auto* sv = suite->getSpikeVector();
     ASSERT_NE(sv, nullptr);
     ASSERT_TRUE(sv->getConfig().managedMode);
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_INTRO);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_INTRO);
 
     // Reduce level count for faster test
     sv->getConfig().levels = 2;
@@ -517,7 +517,7 @@ void spikeVectorManagedModeReturns(SpikeVectorManagedTestSuite* suite) {
     auto& session = sv->getSession();
 
     for (int attempt = 0; attempt < 150; attempt++) {
-        int stateId = sv->getCurrentState()->getStateId();
+        int stateId = sv->getCurrentStateId();
         if (stateId == SPIKE_WIN || stateId == SPIKE_LOSE) break;
 
         if (stateId == SPIKE_INTRO) {
@@ -531,7 +531,7 @@ void spikeVectorManagedModeReturns(SpikeVectorManagedTestSuite* suite) {
                 int firstGap = session.gapPositions[0];
                 suite->tickWithTime(1, 1100);
                 // Now in gameplay, move cursor
-                if (sv->getCurrentState()->getStateId() == SPIKE_GAMEPLAY) {
+                if (sv->getCurrentStateId() == SPIKE_GAMEPLAY) {
                     while (session.cursorPosition > firstGap) {
                         suite->player_.primaryButtonDriver->execCallback(ButtonInteraction::CLICK);
                     }
@@ -555,7 +555,7 @@ void spikeVectorManagedModeReturns(SpikeVectorManagedTestSuite* suite) {
     }
 
     // Should be in Win
-    ASSERT_EQ(sv->getCurrentState()->getStateId(), SPIKE_WIN);
+    ASSERT_EQ(sv->getCurrentStateId(), SPIKE_WIN);
     ASSERT_EQ(sv->getOutcome().result, MiniGameResult::WON);
 
     // Advance past win timer (3s)
@@ -669,7 +669,7 @@ void spikeVectorLoseOnFinalLevel(SpikeVectorTestSuite* suite) {
     suite->game_->skipToState(suite->device_.pdn, 3);  // Evaluate
     suite->tick(3);
 
-    EXPECT_EQ(suite->game_->getCurrentState()->getStateId(), SPIKE_LOSE)
+    EXPECT_EQ(suite->game_->getCurrentStateId(), SPIKE_LOSE)
         << "Should lose even on final level if hits exceed allowed";
 }
 

--- a/test/test_cli/stress-tests.hpp
+++ b/test/test_cli/stress-tests.hpp
@@ -62,7 +62,7 @@ public:
     }
 
     int getStateId() {
-        return device_.game->getCurrentState()->getStateId();
+        return device_.game->getCurrentStateId();
     }
 
     DeviceInstance device_;
@@ -145,14 +145,14 @@ void stressFullGameLifecycles(MinigameStressTestSuite* suite) {
         suite->echo_->skipToState(suite->device_.pdn, 0);
         suite->tick(1);
 
-        EXPECT_EQ(suite->echo_->getCurrentState()->getStateId(), ECHO_INTRO);
+        EXPECT_EQ(suite->echo_->getCurrentStateId(), ECHO_INTRO);
 
         // Skip intro timer
         suite->tickWithTime(5, 500);
 
         // Auto-transition to ShowSequence
         suite->tick(1);
-        EXPECT_EQ(suite->echo_->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+        EXPECT_EQ(suite->echo_->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
 
         // Skip to evaluate without playing
         suite->echo_->skipToState(suite->device_.pdn, 3);
@@ -161,7 +161,7 @@ void stressFullGameLifecycles(MinigameStressTestSuite* suite) {
         // Should be in Lose state (no input provided)
         suite->echo_->skipToState(suite->device_.pdn, 5);
         suite->tick(1);
-        EXPECT_EQ(suite->echo_->getCurrentState()->getStateId(), ECHO_LOSE);
+        EXPECT_EQ(suite->echo_->getCurrentStateId(), ECHO_LOSE);
 
         // Allow outcome to persist
         suite->tickWithTime(5, 100);
@@ -295,7 +295,7 @@ void stressButtonSpamDuringGameplay(MinigameStressTestSuite* suite) {
     suite->tick(1);
 
     // Should be in ShowSequence
-    ASSERT_EQ(suite->echo_->getCurrentState()->getStateId(), ECHO_SHOW_SEQUENCE);
+    ASSERT_EQ(suite->echo_->getCurrentStateId(), ECHO_SHOW_SEQUENCE);
 
     // Wait for player input phase
     suite->tickWithTime(10, 100);

--- a/test/test_cli/wave18-bug-regression-tests.hpp
+++ b/test/test_cli/wave18-bug-regression-tests.hpp
@@ -123,7 +123,7 @@ void testKonamiCLIDoesNotResetProgress(Wave18BugRegressionTestSuite* suite) {
 void testFdnDetectedMessageNotEmptyOnResume(Wave18BugRegressionTestSuite* suite) {
     // Advance to Idle state
     suite->advanceToIdle();
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), IDLE);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), IDLE);
 
     // Simulate FDN detection with a valid challenge message
     std::string fdnChallenge = "*fdn:7:6\r";  // Signal Echo, UP button reward
@@ -131,7 +131,7 @@ void testFdnDetectedMessageNotEmptyOnResume(Wave18BugRegressionTestSuite* suite)
     suite->tick(3);
 
     // Should transition to FdnDetected (state 21)
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), 21);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), 21);
 
     // Get the FdnDetected state
     auto* fdnState = dynamic_cast<FdnDetected*>(suite->quickdraw_->getCurrentState());
@@ -176,7 +176,7 @@ void testFdnDetectedMessageNotEmptyOnResume(Wave18BugRegressionTestSuite* suite)
 void testFdnDetectedLEDsNotBlack(Wave18BugRegressionTestSuite* suite) {
     // Advance to Idle state
     suite->advanceToIdle();
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), IDLE);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), IDLE);
 
     // Simulate FDN detection
     std::string fdnChallenge = "*fdn:7:6\r";  // Signal Echo, UP button reward
@@ -184,7 +184,7 @@ void testFdnDetectedLEDsNotBlack(Wave18BugRegressionTestSuite* suite) {
     suite->tick(3);
 
     // Should transition to FdnDetected (state 21)
-    ASSERT_EQ(suite->quickdraw_->getCurrentState()->getStateId(), 21);
+    ASSERT_EQ(suite->quickdraw_->getCurrentStateId(), 21);
 
     // Get LED state from the light driver
     auto* lightDriver = suite->device_.lightDriver;


### PR DESCRIPTION
## Problem
Wave 20 PRs (#311-#320) all fail CI with SIGSEGV during test cleanup. Issue #298 and #300 identified the root cause: tests call `getCurrentState()->getStateId()` without null checks, causing crashes when `currentState` is null.

## Root Cause
`StateMachine::getCurrentState()` returns `nullptr` when the state machine is:
- **Paused** (line 147 in state-machine.hpp: `onStatePaused()` dismounts current state and sets `currentState = nullptr`)
- **Dismounted** (line 182: `onStateDismounted()` sets `currentState = nullptr`)

Tests had **215 unsafe calls** to `getCurrentState()->getStateId()` across 27 test files. When terminal states (Win/Lose) call `returnToPreviousApp()`, this pauses the game's StateMachine, setting `currentState = nullptr`. Subsequent calls to `getCurrentState()->getStateId()` segfault.

## Solution
1. **Added safe accessor**: `StateMachine::getCurrentStateId()` returns `-1` if `currentState` is null (line 139-141 of state-machine.hpp)
2. **Fixed all unsafe calls**: Replaced all 215 occurrences of `->getCurrentState()->getStateId()` with `->getCurrentStateId()`
3. **Fixed helper methods**: Updated test suite helpers like `getPlayerStateId()` to use the safe accessor

## Files Changed
- `include/state/state-machine.hpp` — Added `getCurrentStateId()` method
- 27 test files in `test/test_cli/` — Replaced unsafe calls

## Verification
✅ **Core tests pass**: `pio test -e native` — all 283 tests pass  
⚠️ **CLI tests**: Cannot verify due to pre-existing GCC 11 internal compiler error (unrelated to this PR)

The GCC ICE is a separate issue affecting the `native_cli_test` build. My changes only add a null check — they cannot cause compiler crashes.

## Impact
This fix should allow Wave 20 PRs to pass CI's test-native job. The test-native-cli job may still fail due to the GCC ICE, but that's a separate issue.

Fixes #298  
Fixes #300