### PR TITLE
fix: initialize DataRecvBuffer to fix cppcheck static-analysis CI

### DIFF
--- a/include/device/drivers/esp32-s3/esp-now-driver.hpp
+++ b/include/device/drivers/esp32-s3/esp-now-driver.hpp
@@ -239,9 +239,9 @@ private:
 
     struct DataRecvBuffer
     {
-        uint8_t* data;
-        unsigned long mostRecentRecvPktTime;
-        uint8_t expectedNextIdx;
+        uint8_t* data = nullptr;
+        unsigned long mostRecentRecvPktTime = 0;
+        uint8_t expectedNextIdx = 0;
     };
 
     explicit EspNowManager(const std::string& name) :


### PR DESCRIPTION
## Summary
- Adds default member initializers to `DataRecvBuffer` struct in `esp-now-driver.hpp`
- Fixes `uninitStructMember` error on `newBuffer.mostRecentRecvPktTime` that was causing the static-analysis CI job to fail on every push to main
- This was the only `error:` level cppcheck finding — all other findings are `warning:`/`style:`/`performance:` which don't fail CI

## Test plan
- [ ] CI static-analysis job passes (cppcheck finds no `error:` level issues)
- [ ] Build-esp32 still compiles successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)