### PR TITLE
feat: TestDevice + contract tests (Phase 1 of #334)

### DIFF
--- a/include/device/drivers/native/native-display-driver.hpp
+++ b/include/device/drivers/native/native-display-driver.hpp
@@ -377,9 +377,7 @@ private:
                 int byteIndex = row * bytesPerRow + col / 8;
                 int bitIndex = col % 8;  // LSB first
                 bool pixelOn = (data[byteIndex] >> bitIndex) & 1;
-                if (pixelOn) {
-                    setPixel(offsetX + col, offsetY + row, true);
-                }
+                setPixel(offsetX + col, offsetY + row, pixelOn);
             }
         }
     }

--- a/test/test_core/contract-tests.hpp
+++ b/test/test_core/contract-tests.hpp
@@ -2,6 +2,15 @@
 
 #include <gtest/gtest.h>
 #include <type_traits>
+#include <cstring>
+#include <vector>
+#include <string>
+
+#include "test-device.hpp"
+#include "game/player.hpp"
+#include "game/match.hpp"
+#include "state/state-machine.hpp"
+#include "../test-constants.hpp"
 
 /*
  * Contract Tests: Native/ESP32 Parity Verification
@@ -31,205 +40,335 @@
 // =============================================================================
 
 class ContractTestSuite : public ::testing::Test {
-protected:
+public:
+    TestDevice* td;
+
     void SetUp() override {
-        // Contract tests typically don't need setup
+        td = new TestDevice();
     }
 
     void TearDown() override {
-        // Contract tests typically don't need teardown
+        delete td;
+        td = nullptr;
     }
 };
-
-// =============================================================================
-// TYPE CONTRACTS: Compile-Time Verification
-// =============================================================================
-
-/*
- * Type contracts use static_assert to verify type properties at compile time.
- * These catch breaking changes to interfaces, data structures, and type traits.
- *
- * Add static_assert checks here for:
- * - RTTI requirements (std::is_polymorphic for base classes with virtual methods)
- * - Size constraints (sizeof checks for serialization compatibility)
- * - Type traits (std::is_trivially_copyable for POD types)
- * - Interface contracts (std::is_base_of for inheritance hierarchies)
- *
- * Example:
- *   static_assert(std::is_polymorphic<Driver>::value,
- *                 "Driver base class must have virtual methods for polymorphism");
- */
-
-// TODO: Add RTTI checks for driver interfaces
-// TODO: Add size checks for serialized types (Player, Match, etc.)
-// TODO: Add inheritance hierarchy checks for state classes
 
 // =============================================================================
 // DISPLAY DRIVER CONTRACT
 // =============================================================================
 
-/*
- * Display Contract: Verifies native and ESP32 display drivers have same behavior
- *
- * The display is critical for gameplay feedback. Native and ESP32 must:
- * - Draw bitmaps identically (including OFF pixels)
- * - Handle text rendering with same layout
- * - Clear screen consistently
- * - Support same contrast/brightness controls (or gracefully no-op)
- */
-
 inline void displayContractBufferSize(ContractTestSuite* suite) {
-    // Example: Verify display buffer dimensions are consistent
-    // const int ESP32_DISPLAY_WIDTH = 128;
-    // const int ESP32_DISPLAY_HEIGHT = 64;
-    //
-    // NativeDisplay nativeDisplay;
-    // EXPECT_EQ(nativeDisplay.getWidth(), ESP32_DISPLAY_WIDTH);
-    // EXPECT_EQ(nativeDisplay.getHeight(), ESP32_DISPLAY_HEIGHT);
+    // Verify display dimensions match ESP32 SSD1306 OLED (128x64)
+    // Use local copies to avoid ODR issues with static const int members
+    int width = NativeDisplayDriver::WIDTH;
+    int height = NativeDisplayDriver::HEIGHT;
+    EXPECT_EQ(width, 128);
+    EXPECT_EQ(height, 64);
 
-    // TODO: Implement actual display buffer size check
-    EXPECT_TRUE(true) << "Display buffer size contract not yet implemented";
+    // Out-of-bounds pixels should return false (not crash)
+    EXPECT_FALSE(suite->td->displayDriver->getPixel(-1, 0));
+    EXPECT_FALSE(suite->td->displayDriver->getPixel(0, -1));
+    EXPECT_FALSE(suite->td->displayDriver->getPixel(128, 0));
+    EXPECT_FALSE(suite->td->displayDriver->getPixel(0, 64));
+    EXPECT_FALSE(suite->td->displayDriver->getPixel(999, 999));
 }
 
 inline void displayContractDrawBitmapWritesBothOnAndOffPixels(ContractTestSuite* suite) {
-    // Example: Verify drawXBMP writes both ON and OFF pixels (not just ON)
-    // This prevents native driver from taking shortcuts
-    //
-    // NativeDisplay display;
-    // display.clearBuffer();
-    //
-    // // Draw a bitmap with explicit OFF pixels in the middle of ON pixels
-    // const uint8_t testBitmap[] = { 0xFF, 0x00, 0xFF }; // ON OFF ON pattern
-    // display.drawXBMP(0, 0, 8, 3, testBitmap);
-    //
-    // // Verify OFF pixels were actually written (not skipped)
-    // EXPECT_EQ(display.getPixel(0, 1), 0) << "OFF pixels must be written, not skipped";
+    NativeDisplayDriver* display = suite->td->displayDriver;
 
-    // TODO: Implement actual bitmap write verification
-    EXPECT_TRUE(true) << "Bitmap write contract not yet implemented";
+    // Fill a region with ON pixels using drawBox
+    display->drawBox(0, 0, 8, 3);
+
+    // Verify the region is filled
+    for (int y = 0; y < 3; y++) {
+        for (int x = 0; x < 8; x++) {
+            ASSERT_TRUE(display->getPixel(x, y))
+                << "Pixel (" << x << "," << y << ") should be ON after drawBox";
+        }
+    }
+
+    // Create XBM bitmap: row 0 = 0xFF (all ON), row 1 = 0x00 (all OFF), row 2 = 0xFF (all ON)
+    // XBM is 1 byte per row for 8px wide images, LSB first
+    const unsigned char testBitmap[] = { 0xFF, 0x00, 0xFF };
+
+    // Draw the bitmap over the filled region using drawImage
+    Image testImage(testBitmap, 8, 3, 0, 0);
+    display->drawImage(testImage, 0, 0);
+
+    // Row 0: all ON (0xFF) — should still be ON
+    for (int x = 0; x < 8; x++) {
+        EXPECT_TRUE(display->getPixel(x, 0))
+            << "Row 0, pixel " << x << " should be ON (0xFF byte)";
+    }
+
+    // Row 1: all OFF (0x00) — must overwrite the ON pixels from drawBox
+    for (int x = 0; x < 8; x++) {
+        EXPECT_FALSE(display->getPixel(x, 1))
+            << "Row 1, pixel " << x << " should be OFF — XBM OFF pixels must overwrite ON pixels";
+    }
+
+    // Row 2: all ON (0xFF) — should be ON
+    for (int x = 0; x < 8; x++) {
+        EXPECT_TRUE(display->getPixel(x, 2))
+            << "Row 2, pixel " << x << " should be ON (0xFF byte)";
+    }
 }
 
 // =============================================================================
 // BUTTON DRIVER CONTRACT
 // =============================================================================
 
-/*
- * Button Contract: Verifies native and ESP32 button drivers handle events identically
- *
- * Critical for gameplay timing (quickdraw, etc.). Both drivers must:
- * - Debounce with same timing parameters
- * - Support same event types (click, hold, double-click if applicable)
- * - Fire callbacks in same order
- */
+// Static flag for button contract test (callbackFunction is a plain function pointer, no captures)
+static bool s_buttonContractCallbackFired = false;
+static void buttonContractCallback() { s_buttonContractCallbackFired = true; }
 
 inline void buttonContractDebounceTimingMatches(ContractTestSuite* suite) {
-    // TODO: Verify native and ESP32 debounce timing is identical
-    // This prevents "works in CLI but not on hardware" timing bugs
-    EXPECT_TRUE(true) << "Button debounce contract not yet implemented";
+    NativeButtonDriver* button = suite->td->primaryButtonDriver;
+
+    // Verify callback registration and dispatch
+    s_buttonContractCallbackFired = false;
+    button->setButtonPress(buttonContractCallback, ButtonInteraction::PRESS);
+
+    EXPECT_TRUE(button->hasCallback(ButtonInteraction::PRESS));
+    EXPECT_FALSE(s_buttonContractCallbackFired) << "Callback should not fire on registration";
+
+    // Fire the callback
+    button->execCallback(ButtonInteraction::PRESS);
+    EXPECT_TRUE(s_buttonContractCallbackFired) << "Callback should fire on execCallback";
+
+    // Verify removeButtonCallbacks clears all
+    s_buttonContractCallbackFired = false;
+    button->removeButtonCallbacks();
+    EXPECT_FALSE(button->hasCallback(ButtonInteraction::PRESS));
+
+    // execCallback after removal should not crash (no-op)
+    button->execCallback(ButtonInteraction::PRESS);
+    EXPECT_FALSE(s_buttonContractCallbackFired) << "Callback should not fire after removal";
+
+    // Document: native driver doesn't simulate debounce timing — callbacks are instant.
+    // On ESP32, OneButton handles debounce (~50ms). Tests that depend on debounce
+    // timing must be run on hardware.
 }
 
 // =============================================================================
 // SERIAL DRIVER CONTRACT
 // =============================================================================
 
-/*
- * Serial Contract: Verifies native and ESP32 serial communication matches
- *
- * Critical for cable-based minigames (FDN protocol). Both drivers must:
- * - Respect same buffer size limits
- * - Handle buffer overflow identically
- * - Support same baud rates (or gracefully no-op on native)
- * - Deliver messages in same order
- */
-
 inline void serialContractBufferSizeLimits(ContractTestSuite* suite) {
-    // TODO: Verify serial buffer overflow handling matches between platforms
-    // ESP32 has hardware buffer limits; native must simulate same limits
-    EXPECT_TRUE(true) << "Serial buffer contract not yet implemented";
+    NativeSerialDriver* serial = suite->td->serialOutDriver;
+
+    // Verify buffer size constants match ESP32 hardware limits
+    // Use local copies to avoid ODR issues with static const members
+    size_t maxOutputSize = NativeSerialDriver::MAX_OUTPUT_BUFFER_SIZE;
+    size_t maxInputSize = NativeSerialDriver::MAX_INPUT_QUEUE_SIZE;
+    EXPECT_EQ(maxOutputSize, 255u);
+    EXPECT_EQ(maxInputSize, 32u);
+
+    // Test output buffer: write a long string that exceeds MAX_OUTPUT_BUFFER_SIZE
+    std::string longMessage(300, 'A');
+    serial->println(longMessage);
+    std::string output = serial->getOutput();
+    EXPECT_LE(output.size(), maxOutputSize)
+        << "Output buffer should be trimmed to MAX_OUTPUT_BUFFER_SIZE";
+    serial->clearOutput();
+
+    // Test input queue: inject more than MAX_INPUT_QUEUE_SIZE messages
+    for (int i = 0; i < 40; i++) {
+        serial->injectInput("msg" + std::to_string(i));
+    }
+
+    // Count how many messages are available
+    int count = 0;
+    while (serial->available()) {
+        serial->readStringUntil('\n');
+        count++;
+    }
+    EXPECT_LE(count, static_cast<int>(maxInputSize))
+        << "Input queue should not exceed MAX_INPUT_QUEUE_SIZE";
 }
 
 // =============================================================================
 // TIMER DRIVER CONTRACT
 // =============================================================================
 
-/*
- * Timer Contract: Verifies native and ESP32 timer behavior matches
- *
- * Critical for time-sensitive gameplay (quickdraw timing, FDN timeouts). Must:
- * - Handle overflow identically (millis() rollover at ~49 days)
- * - Support same precision (millisecond-level accuracy)
- * - Provide deterministic behavior in tests (mocked time)
- */
-
 inline void timerContractOverflowHandling(ContractTestSuite* suite) {
-    // TODO: Verify millis() overflow is handled identically
-    // Example: Test with time values near UINT32_MAX
-    EXPECT_TRUE(true) << "Timer overflow contract not yet implemented";
+    // Create a minimal PlatformClock with settable time for overflow testing
+    class OverflowClock : public PlatformClock {
+    public:
+        uint32_t time = 0;
+        unsigned long milliseconds() override { return time; }
+    };
+
+    OverflowClock overflowClock;
+
+    // Save and replace the global clock
+    PlatformClock* savedClock = SimpleTimer::getPlatformClock();
+    SimpleTimer::setPlatformClock(&overflowClock);
+
+    // Set clock near UINT32_MAX
+    overflowClock.time = UINT32_MAX - 5;  // 5ms before overflow
+
+    SimpleTimer timer;
+    timer.setTimer(20);  // 20ms duration — will cross the overflow boundary
+
+    // Advance past the overflow boundary
+    overflowClock.time = 10;  // wrapped around: elapsed = 5 + 10 + 1 = 16ms
+
+    EXPECT_FALSE(timer.expired()) << "Timer should not be expired at 16ms (duration=20ms)";
+    EXPECT_EQ(timer.getElapsedTime(), 16u) << "Elapsed time should handle overflow correctly";
+
+    // Advance past expiry
+    overflowClock.time = 20;  // elapsed = 5 + 20 + 1 = 26ms
+    EXPECT_TRUE(timer.expired()) << "Timer should be expired at 26ms (duration=20ms)";
+    EXPECT_EQ(timer.getElapsedTime(), 26u);
+
+    // Restore original clock
+    SimpleTimer::setPlatformClock(savedClock);
 }
 
 // =============================================================================
 // STATE MACHINE CONTRACT
 // =============================================================================
 
-/*
- * State Machine Contract: Verifies state lifecycle is identical across platforms
- *
- * The state machine is the core of game logic. Must verify:
- * - Same state transition order
- * - Same lifecycle call patterns (onStateMounted -> onStateLoop -> onStateDismounted)
- * - Same message handling behavior
- * - No platform-specific state hacks
- */
-
 inline void stateMachineContractLifecycleOrder(ContractTestSuite* suite) {
-    // TODO: Verify state lifecycle methods are called in same order on both platforms
-    // Use mock states to track call order
-    EXPECT_TRUE(true) << "State machine lifecycle contract not yet implemented";
+    // Tracked states that log lifecycle events with timestamps
+    static std::vector<std::string> events;
+    events.clear();
+
+    class TrackedStateA : public State {
+    public:
+        bool shouldTransition = false;
+        TrackedStateA() : State(0) {}
+        void onStateMounted(Device* d) override { events.push_back("A_mount"); }
+        void onStateLoop(Device* d) override {
+            events.push_back("A_loop");
+            shouldTransition = true;
+        }
+        void onStateDismounted(Device* d) override { events.push_back("A_dismount"); }
+    };
+
+    class TrackedStateB : public State {
+    public:
+        TrackedStateB() : State(1) {}
+        void onStateMounted(Device* d) override { events.push_back("B_mount"); }
+        void onStateLoop(Device* d) override { events.push_back("B_loop"); }
+        void onStateDismounted(Device* d) override { events.push_back("B_dismount"); }
+    };
+
+    class TrackedMachine : public StateMachine {
+    public:
+        TrackedMachine() : StateMachine(100) {}
+        void populateStateMap() override {
+            auto* a = new TrackedStateA();
+            auto* b = new TrackedStateB();
+            stateMap.push_back(a);
+            stateMap.push_back(b);
+            a->addTransition(new StateTransition(
+                [a]() { return a->shouldTransition; }, b));
+        }
+    };
+
+    TrackedMachine machine;
+    machine.initialize(suite->td->pdn);
+
+    // After initialize: state A should be mounted
+    ASSERT_EQ(events.size(), 1u);
+    EXPECT_EQ(events[0], "A_mount");
+
+    // Run one loop — A loops, transition fires, A dismounts, B mounts
+    machine.onStateLoop(suite->td->pdn);
+
+    ASSERT_GE(events.size(), 4u) << "Expected at least 4 events after one loop";
+    EXPECT_EQ(events[1], "A_loop");
+    EXPECT_EQ(events[2], "A_dismount");
+    EXPECT_EQ(events[3], "B_mount");
+
+    // Verify dismount happens before mount (ordering guarantee)
+    int dismountIndex = -1, mountIndex = -1;
+    for (size_t i = 0; i < events.size(); i++) {
+        if (events[i] == "A_dismount" && dismountIndex == -1) dismountIndex = static_cast<int>(i);
+        if (events[i] == "B_mount" && mountIndex == -1) mountIndex = static_cast<int>(i);
+    }
+    EXPECT_LT(dismountIndex, mountIndex)
+        << "A_dismount must occur before B_mount";
+
+    // Clean up — shutdown to dismount B before machine destructor
+    machine.shutdown(suite->td->pdn);
 }
 
 // =============================================================================
 // SERIALIZATION CONTRACT
 // =============================================================================
 
-/*
- * Serialization Contract: Verifies Player/Match JSON/binary output is identical
- *
- * Critical for cross-device communication and data persistence. Must verify:
- * - Same JSON field order (where order matters for compatibility)
- * - Same binary layout (for wire protocol)
- * - Same handling of null/default values
- */
-
 inline void serializationContractPlayerJsonFormat(ContractTestSuite* suite) {
-    // TODO: Verify Player JSON serialization produces identical output
-    // Create Player, serialize to JSON, verify field presence and format
-    EXPECT_TRUE(true) << "Player serialization contract not yet implemented";
+    // Create a Player with identity fields set
+    Player original;
+    original.setUserID(const_cast<char*>(TestConstants::TEST_UUID_PLAYER_1));
+    original.setName("TestRunner");
+    original.setAllegiance(Allegiance::HELIX);
+    original.setFaction("Neon");
+    original.setIsHunter(true);
+
+    // Round trip: toJson → fromJson
+    std::string json = original.toJson();
+    Player restored;
+    restored.fromJson(json);
+
+    EXPECT_EQ(restored.getUserID(), original.getUserID());
+    EXPECT_EQ(restored.getName(), original.getName());
+    EXPECT_EQ(restored.getFaction(), original.getFaction());
+    EXPECT_EQ(restored.isHunter(), original.isHunter());
+
+    // Double round-trip: verify stability (toJson → fromJson → toJson → fromJson)
+    std::string json2 = restored.toJson();
+    Player restored2;
+    restored2.fromJson(json2);
+
+    EXPECT_EQ(restored2.getUserID(), original.getUserID());
+    EXPECT_EQ(restored2.getName(), original.getName());
+    EXPECT_EQ(restored2.getFaction(), original.getFaction());
+    EXPECT_EQ(restored2.isHunter(), original.isHunter());
+
+    // Verify the two JSON strings are identical (stable serialization)
+    EXPECT_EQ(json, json2)
+        << "Double round-trip JSON should be identical to first round-trip";
 }
 
 inline void serializationContractMatchBinaryFormat(ContractTestSuite* suite) {
-    // TODO: Verify Match binary serialization matches across platforms
-    // Critical for networked gameplay
-    EXPECT_TRUE(true) << "Match serialization contract not yet implemented";
+    // Create a Match with valid UUID format strings (required for binary serialization)
+    Match original(TestConstants::TEST_UUID_MATCH_1,
+                   TestConstants::TEST_UUID_HUNTER_1,
+                   TestConstants::TEST_UUID_BOUNTY_1);
+    original.setHunterDrawTime(150);
+    original.setBountyDrawTime(200);
+
+    // Serialize → deserialize round trip
+    uint8_t buffer[MATCH_BINARY_SIZE];
+    size_t written = original.serialize(buffer);
+    EXPECT_EQ(written, MATCH_BINARY_SIZE);
+
+    Match restored;
+    size_t bytesRead = restored.deserialize(buffer);
+    EXPECT_EQ(bytesRead, MATCH_BINARY_SIZE);
+
+    // Verify all fields match
+    EXPECT_EQ(restored.getMatchId(), original.getMatchId());
+    EXPECT_EQ(restored.getHunterId(), original.getHunterId());
+    EXPECT_EQ(restored.getBountyId(), original.getBountyId());
+    EXPECT_EQ(restored.getHunterDrawTime(), original.getHunterDrawTime());
+    EXPECT_EQ(restored.getBountyDrawTime(), original.getBountyDrawTime());
+
+    // Verify deterministic output: serialize a duplicate and memcmp
+    Match duplicate(TestConstants::TEST_UUID_MATCH_1,
+                    TestConstants::TEST_UUID_HUNTER_1,
+                    TestConstants::TEST_UUID_BOUNTY_1);
+    duplicate.setHunterDrawTime(150);
+    duplicate.setBountyDrawTime(200);
+
+    uint8_t buffer2[MATCH_BINARY_SIZE];
+    size_t written2 = duplicate.serialize(buffer2);
+    EXPECT_EQ(written2, MATCH_BINARY_SIZE);
+
+    EXPECT_EQ(memcmp(buffer, buffer2, MATCH_BINARY_SIZE), 0)
+        << "Identical matches must produce identical binary output";
 }
-
-// =============================================================================
-// REGISTRATION (add to tests.cpp)
-// =============================================================================
-
-/*
- * To register these tests, add the following to tests.cpp:
- *
- * #include "contract-tests.hpp"
- *
- * Then add TEST_F macros for each test function:
- *
- * TEST_F(ContractTestSuite, displayBufferSize) {
- *     displayContractBufferSize(this);
- * }
- *
- * TEST_F(ContractTestSuite, displayDrawBitmapWritesBothOnAndOffPixels) {
- *     displayContractDrawBitmapWritesBothOnAndOffPixels(this);
- * }
- *
- * ... etc for each inline function above
- */

--- a/test/test_core/test-device.hpp
+++ b/test/test_core/test-device.hpp
@@ -1,0 +1,119 @@
+#pragma once
+
+#include <string>
+
+// Native drivers
+#include "device/drivers/native/native-logger-driver.hpp"
+#include "device/drivers/native/native-clock-driver.hpp"
+#include "device/drivers/native/native-display-driver.hpp"
+#include "device/drivers/native/native-button-driver.hpp"
+#include "device/drivers/native/native-light-strip-driver.hpp"
+#include "device/drivers/native/native-haptics-driver.hpp"
+#include "device/drivers/native/native-serial-driver.hpp"
+#include "device/drivers/native/native-http-client-driver.hpp"
+#include "device/drivers/native/native-peer-comms-driver.hpp"
+#include "device/drivers/native/native-prefs-driver.hpp"
+
+// Core
+#include "device/pdn.hpp"
+#include "utils/simple-timer.hpp"
+
+/*
+ * TestDevice: RAII wrapper around PDN with all 12 native drivers.
+ *
+ * Unlike MockDevice (which uses GMock interfaces), TestDevice uses real native
+ * drivers — the same ones the CLI simulator uses. This gives tests access to
+ * actual driver behavior (buffer limits, pixel state, callback dispatch) instead
+ * of mocked expectations.
+ *
+ * TestDevice coexists with MockDevice. Existing tests continue to use MockDevice;
+ * new tests (starting with contract tests) use TestDevice.
+ *
+ * Usage:
+ *   TestDevice td;
+ *   td.pdn->begin();
+ *   td.displayDriver->getPixel(0, 0);
+ *   td.pressButton();
+ */
+class TestDevice {
+public:
+    // The PDN instance — pass to anything needing Device*
+    PDN* pdn;
+
+    // Typed driver pointers (non-owning — PDN owns via DriverManager)
+    NativeDisplayDriver* displayDriver;
+    NativeButtonDriver* primaryButtonDriver;
+    NativeButtonDriver* secondaryButtonDriver;
+    NativeHapticsDriver* hapticsDriver;
+    NativeClockDriver* clockDriver;
+    NativeSerialDriver* serialOutDriver;
+    NativeSerialDriver* serialInDriver;
+    NativeLightStripDriver* lightDriver;
+    NativeHttpClientDriver* httpClientDriver;
+    NativePeerCommsDriver* peerCommsDriver;
+    NativePrefsDriver* storageDriver;
+    NativeLoggerDriver* loggerDriver;
+
+    TestDevice() {
+        // Allocate all 12 native drivers
+        loggerDriver = new NativeLoggerDriver(LOGGER_DRIVER_NAME);
+        loggerDriver->setSuppressOutput(true);
+        clockDriver = new NativeClockDriver(PLATFORM_CLOCK_DRIVER_NAME);
+        displayDriver = new NativeDisplayDriver(DISPLAY_DRIVER_NAME);
+        primaryButtonDriver = new NativeButtonDriver(PRIMARY_BUTTON_DRIVER_NAME, 0);
+        secondaryButtonDriver = new NativeButtonDriver(SECONDARY_BUTTON_DRIVER_NAME, 1);
+        lightDriver = new NativeLightStripDriver(LIGHT_DRIVER_NAME);
+        hapticsDriver = new NativeHapticsDriver(HAPTICS_DRIVER_NAME, 0);
+        serialOutDriver = new NativeSerialDriver(SERIAL_OUT_DRIVER_NAME);
+        serialInDriver = new NativeSerialDriver(SERIAL_IN_DRIVER_NAME);
+        httpClientDriver = new NativeHttpClientDriver(HTTP_CLIENT_DRIVER_NAME);
+        peerCommsDriver = new NativePeerCommsDriver(PEER_COMMS_DRIVER_NAME);
+        storageDriver = new NativePrefsDriver(STORAGE_DRIVER_NAME);
+
+        // Build DriverConfig map
+        DriverConfig config = {
+            {DISPLAY_DRIVER_NAME, displayDriver},
+            {PRIMARY_BUTTON_DRIVER_NAME, primaryButtonDriver},
+            {SECONDARY_BUTTON_DRIVER_NAME, secondaryButtonDriver},
+            {LIGHT_DRIVER_NAME, lightDriver},
+            {HAPTICS_DRIVER_NAME, hapticsDriver},
+            {SERIAL_OUT_DRIVER_NAME, serialOutDriver},
+            {SERIAL_IN_DRIVER_NAME, serialInDriver},
+            {HTTP_CLIENT_DRIVER_NAME, httpClientDriver},
+            {PEER_COMMS_DRIVER_NAME, peerCommsDriver},
+            {PLATFORM_CLOCK_DRIVER_NAME, clockDriver},
+            {LOGGER_DRIVER_NAME, loggerDriver},
+            {STORAGE_DRIVER_NAME, storageDriver},
+        };
+
+        // Create PDN (takes ownership of drivers via DriverManager)
+        pdn = PDN::createPDN(config);
+
+        // Set platform clock for SimpleTimer
+        SimpleTimer::setPlatformClock(clockDriver);
+    }
+
+    ~TestDevice() {
+        // Reset global clock before destroying PDN
+        SimpleTimer::resetClock();
+
+        // delete pdn cascades: PDN::~PDN() → shutdownApps() → ~Device() → dismountDrivers()
+        // which deletes all drivers. After this, all driver pointers are dangling.
+        delete pdn;
+    }
+
+    // Simulate a button press on the primary button
+    void pressButton(ButtonInteraction interaction = ButtonInteraction::PRESS) {
+        primaryButtonDriver->execCallback(interaction);
+    }
+
+    // Inject a serial message into the output jack (as if received from cable)
+    void simulateSerialReceive(const std::string& message) {
+        serialOutDriver->injectInput(message);
+    }
+
+    // Advance the clock by the given number of milliseconds
+    void advanceTime(unsigned long ms) {
+        clockDriver->advance(ms);
+    }
+};


### PR DESCRIPTION
## Summary

Phase 1 of #334 — creates the foundation for eliminating GMock from `test_core/` tests.

- **TestDevice** (`test/test_core/test-device.hpp`): RAII wrapper around `PDN` with all 12 native drivers, exposing typed pointers for test inspection. Coexists with `MockDevice` — no existing tests modified.
- **8 contract tests** (`test/test_core/contract-tests.hpp`): Replace stub implementations with real assertions using native drivers:
  1. Display buffer size (128×64) + out-of-bounds safety
  2. XBM bitmap OFF pixel parity (native matches U8g2 behavior)
  3. Button callback registration, dispatch, and removal
  4. Serial buffer size limits (255 output, 32 input queue)
  5. Timer overflow handling across `UINT32_MAX` boundary
  6. State machine lifecycle ordering (mount→loop→dismount→mount)
  7. Player JSON round-trip stability
  8. Match binary round-trip + deterministic output
- **XBM bug fix** (`native-display-driver.hpp`): `decodeXBMToBuffer()` now writes both ON and OFF pixels, matching ESP32's U8g2 `drawXBMP()` behavior

## Test plan

- [x] All 371 core tests pass (`pio test -e native`)
- [x] All 375 CLI tests pass (`pio test -e native_cli_test`)
- [x] All 8 contract tests pass with real assertions
- [x] CLI simulator builds (`pio run -e native_cli`)
- [ ] CI passes

Fixes #334 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)