### PR TITLE
fix: systemic SIGSEGV fix for Device destruction ordering (#331)

### DIFF
--- a/src/device/device.cpp
+++ b/src/device/device.cpp
@@ -6,10 +6,11 @@
 const char* TAG = "Device";
 
 Device::~Device() {
-    // shutdownApps() is called here for test mocks and simple Device subclasses.
-    // For PDN, shutdownApps() is called first in PDN::~PDN() (while the vtable
-    // still has PDN's virtual method implementations). The second call here is
-    // a no-op since shutdownApps() clears appConfig after processing.
+    // shutdownApps() is called here as a safety fallback for any Device subclass
+    // that forgets to call it in its own destructor. For PDN and MockDevice,
+    // shutdownApps() is called first in their destructors (while the vtable still
+    // has their virtual method implementations). The second call here is a no-op
+    // since shutdownApps() clears appConfig after processing.
     shutdownApps();
     driverManager.dismountDrivers();
 }

--- a/test/test_core/device-mock.hpp
+++ b/test/test_core/device-mock.hpp
@@ -207,6 +207,10 @@ public:
     }
 
     ~MockDevice() {
+        // Shutdown apps here (not in ~Device) because state dismount callbacks
+        // may call virtual methods. During ~Device(), the vtable reverts to
+        // Device's pure virtual definitions, causing SIGSEGV.
+        shutdownApps();
         delete mockDisplay;
         delete mockPrimaryButton;
         delete mockSecondaryButton;


### PR DESCRIPTION
Fixes #331

## Problem
SIGSEGV crash during test teardown after all tests pass. The `Device` destructor calls `shutdownApps()`, which calls `StateMachine::shutdown(this)`. By that point in destruction, the derived class vtable (e.g. `MockDevice`, `PDN`) has already unwound. Any virtual method calls on `this` during base class destruction dispatch to destroyed vtable — causing a crash.

## Root Cause
Classic C++ destruction-order problem: base class destructor calling virtual functions. The derived class portion is already destroyed when `~Device()` runs, so virtual dispatch on `this` is undefined behavior.

## Solution
Make `MockDevice` call `shutdownApps()` in its destructor (just like `PDN` already does). This ensures state machines are dismounted while the vtable still has the derived class's virtual methods intact.

**Before**: `MockDevice` relied on `~Device()` to call `shutdownApps()`, but by then the vtable had reverted to Device's pure virtuals.

**After**: Both `PDN` and `MockDevice` call `shutdownApps()` in their own destructors before `~Device()` runs. `~Device()` still calls `shutdownApps()` as a safety fallback (idempotent due to `appConfig.clear()`).

## Systemic Fix
This establishes a pattern: **any future `Device` subclass must call `shutdownApps()` in its destructor** to avoid destruction-order bugs. The base class provides a safety net, but subclasses must not rely on it.

## Files Changed
- `test/test_core/device-mock.hpp` - Added `shutdownApps()` call to `MockDevice::~MockDevice()`
- `src/device/device.cpp` - Updated comment to reflect the new pattern

## Tests
✅ All core tests pass: `pio test -e native` (392/392)
✅ All CLI tests pass: `pio test -e native_cli_test` (375/375)
✅ No SIGSEGV crashes during teardown

## Unblocks
- PR #311
- PR #319