### PR TITLE
infra: add Mergify merge queue (#343)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,13 @@
+queue_rules:
+  - name: default
+    batch_size: 5
+    batch_max_wait_time: 2 min
+    merge_method: squash
+    queue_conditions:
+      - base = main
+    merge_conditions:
+      - check-success = test-native
+      - check-success = test-native-cli
+      - check-success = test
+      - check-success = build-esp32
+      - check-success = build-cli


### PR DESCRIPTION
## Summary

Adds Mergify merge queue configuration to prevent batch-merge breakage that has broken main in Waves 17, 18, 19, and 20.

## What this does

- Adds `.mergify.yml` with merge queue config
- Batches up to 5 PRs per CI run
- Requires all 5 CI checks to pass on the combined batch before merging
- Auto-bisects failures to isolate the bad PR

## What still needs to happen (manual)

**Install the Mergify GitHub App on this repo:**
1. Go to https://github.com/apps/mergify/installations/new
2. Select the `FinallyEve` account
3. Grant access to the `pdn` repo
4. That's it — Mergify reads `.mergify.yml` from the repo automatically

## How the orchestrator uses it

Instead of:
```
gh pr merge <N> --squash          # OLD — causes batch breakage
```

Do:
```
@mergifyio queue                  # Comment this on a PR to add it to the queue
```

Or use the Mergify dashboard to manage the queue.

## Config explained

```yaml
queue_rules:
  - name: default
    batch_size: 5              # Test 5 PRs combined in one CI run
    batch_max_wait_time: 2 min # Wait up to 2 min to fill the batch
    merge_method: squash       # Clean single-commit-per-PR history
    queue_conditions:
      - base = main            # Only queue PRs targeting main
    merge_conditions:          # All 5 CI checks must pass on the batch
      - check-success = test-native
      - check-success = test-native-cli
      - check-success = test
      - check-success = build-esp32
      - check-success = build-cli
```

No CI workflow changes needed — Mergify creates draft PRs that trigger existing `pull_request` CI events.

Fixes #343