### PR TITLE
infra: add Mergify merge queue configuration (#343)

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,38 @@
+# Mergify Configuration — Merge Queue for PDN
+# Replaces batch merging to prevent "passes individually, fails together" breakage
+# See: #343, #282
+
+queue_rules:
+  - name: default
+    merge_method: squash
+    merge_conditions:
+      - check-success = test-native
+      - check-success = test-native-cli
+      - check-success = test
+      - check-success = build-esp32
+      - check-success = build-cli
+    batch_size: 5
+    batch_max_wait_time: 5 min
+    checks_timeout: 30 min
+    commit_message_template: |
+      {{ title }} (#{{ number }})
+
+      {{ body | get_section("## Summary", "") }}
+
+pull_request_rules:
+  - name: queue PRs with ready-to-merge label
+    conditions:
+      - base = main
+      - label = ready-to-merge
+      - -draft
+    actions:
+      queue:
+        name: default
+
+  - name: remove from queue when label removed
+    conditions:
+      - base = main
+      - label != ready-to-merge
+      - queue-position >= 0
+    actions:
+      dequeue:


### PR DESCRIPTION
## Summary
- Adds `.mergify.yml` with merge queue configuration
- Orchestrator adds `ready-to-merge` label → Mergify queues the PR → CI runs on combined branch → merges if green
- Batch size 5, 30min timeout, squash merge
- Replaces direct batch merging that broke main on Waves 17, 18, 19, and 20

## How it works
1. Orchestrator (or reviewer) adds `ready-to-merge` label to approved PRs
2. Mergify creates draft PRs combining queued PRs and runs CI on those
3. If CI passes on the combined result, Mergify squash-merges to main
4. If a batch fails, Mergify bisects to find the culprit and ejects it

## Required CI checks
- `test-native`, `test-native-cli` (build-gate)
- `test`, `build-esp32`, `build-cli` (pr-checks)

## One-time setup (already done)
- [x] Mergify GitHub App installed on repo
- [x] `ready-to-merge` label exists
- [ ] Verify "Require branches to be up to date" is OFF in branch protection (currently not set — good)

Fixes #343