### PR TITLE
infra: add Mergify ready-to-merge rule + CI failure template + smoke test (#351)

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci-failure.md
+++ b/.github/ISSUE_TEMPLATE/ci-failure.md
@@ -1,0 +1,26 @@
+---
+name: CI Failure Report
+about: Report a CI failure on main or a PR
+labels: ci-failure
+---
+
+## Severity
+<!-- P0: main broken / P1: single PR / P2: CI infra / P3: warning -->
+
+## Failing Tests
+<!-- List exact test names or "compile error in <file>" -->
+
+## Error Output
+<!-- Paste the relevant compiler error or test failure output (truncated) -->
+
+## Root Cause
+<!-- Which PR(s) or merge(s) caused this? What changed? -->
+
+## Affected Files
+<!-- List files that need to be modified to fix this -->
+
+## Reproduction
+<!-- Exact command: e.g., pio test -e native_cli_test -->
+
+## Blast Radius
+<!-- How many agents/PRs are blocked? Is main broken? -->

--- a/.github/workflows/post-merge-smoke.yml
+++ b/.github/workflows/post-merge-smoke.yml
@@ -1,0 +1,26 @@
+name: Post-Merge Smoke Test
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+      - '*.md'
+      - 'demos/**'
+
+jobs:
+  smoke-test:
+    runs-on: [self-hosted, linux, x64]
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install PlatformIO
+        run: pip install platformio
+      - name: Run core tests
+        run: pio test -e native
+      - name: Run CLI tests
+        run: pio test -e native_cli_test
+      - name: Build CLI
+        run: pio run -e native_cli

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -69,6 +69,17 @@ priority_rules:
     priority: medium
 
 pull_request_rules:
+  # Queue PRs with ready-to-merge label into default queue
+  - name: queue PRs with ready-to-merge label
+    conditions:
+      - base = main
+      - label = ready-to-merge
+      - -label = do-not-merge
+      - -draft
+    actions:
+      queue:
+        name: default
+
   # Auto-queue P0 bug fixes into urgent lane
   - name: auto-queue urgent bug fixes
     conditions:


### PR DESCRIPTION
## Summary
- Adds ready-to-merge label queue rule to Mergify config
- Creates CI failure issue template with required fields (severity, failing tests, root cause, blast radius)
- Adds post-merge smoke test workflow for automated main branch validation

Fixes #351
Ref #322

## Test plan
- [x] Mergify YAML validates
- [x] Issue template renders correctly
- [x] Smoke test workflow syntax valid
- [x] All existing tests pass